### PR TITLE
Switched --fasta and --genomes descriptions, added software links

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,6 +69,19 @@ Be warned of two important points about this default configuration:
     * See the [nextflow docs](https://www.nextflow.io/docs/latest/executor.html) for information about running with other hardware backends. Most job scheduler systems are natively supported.
 2. Nextflow will expect all software to be installed and available on the `PATH`
 
+The following software is currently required to be installed:
+
+* [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)
+* [Picard Tools](https://broadinstitute.github.io/picard/)
+* [Samtools](http://www.htslib.org/)
+* [Preseq](http://smithlabresearch.org/software/preseq/)
+* [MultiQC](https://multiqc.info/)
+* [BWA](http://bio-bwa.sourceforge.net/)
+* [Qualimap](http://qualimap.bioinfo.cipf.es/)
+* [GATK](https://software.broadinstitute.org/gatk/)
+* [bamUtil](https://genome.sph.umich.edu/wiki/BamUtil)
+* [fastP](https://github.com/OpenGene/fastp)
+
 #### 3.1) Software deps: Docker
 First, install docker on your system: [Docker Installation Instructions](https://docs.docker.com/engine/installation/)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,9 +140,18 @@ It is not possible to run a mixture of single-end and paired-end files in one ru
 
 ## Reference Genomes
 
-The pipeline config files come bundled with paths to the illumina iGenomes reference index files. If running with docker or AWS, the configuration is set up to use the [AWS-iGenomes](https://ewels.github.io/AWS-iGenomes/) resource.
+### `--fasta`
+If you prefer, you can specify the full path to your reference genome when you run the pipeline:
+
+```bash
+--fasta '[path to Fasta reference]'
+```
+> If you don't specify appropriate `--bwa_index`, `--fasta_index` parameters, the pipeline will create these indices for you automatically. Note, that saving these for later has to be turned on using `--saveReference`.
 
 ### `--genome` (using iGenomes)
+
+The pipeline config files come bundled with paths to the illumina iGenomes reference index files. If running with docker or AWS, the configuration is set up to use the [AWS-iGenomes](https://ewels.github.io/AWS-iGenomes/) resource.
+
 There are 31 different species supported in the iGenomes references. To run the pipeline, you must specify which to use with the `--genome` flag.
 
 You can find the keys to specify the genomes in the [iGenomes config file](../conf/igenomes.config). Common genomes that are supported are:
@@ -173,14 +182,6 @@ params {
   }
 }
 ```
-
-### `--fasta`
-If you prefer, you can specify the full path to your reference genome when you run the pipeline:
-
-```bash
---fasta '[path to Fasta reference]'
-```
-> If you don't specify appropriate `--bwa_index`, `--fasta_index` parameters, the pipeline will create these indices for you automatically. Note, that saving these for later has to be turned on using `--saveReference`.
 
 ### `--bwa_index`
 


### PR DESCRIPTION
Switch `--fasta` and `--genome` flag descriptions as I think people are more likely to use their own lab's default references than iGenomes.

It could confuse things if a new user came in and isn't aware of the difference.

Futhermore, added to the `docs/installation.md` file a list of software used within the pipeline. I might also add the citations down the line. Feel free to move if in the wrong place.

## PR checklist
 - [x ] This comment contains a description of changes (with reason)

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
