### PR TITLE
Bamtrim udghalf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,6 @@ script:
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --singleEnd 
   # Run the same pipeline testing optional step: fastp, complexity 
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --complexity_filter 
+  # Test BAM Trimming
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --trim_bam 
 

--- a/main.nf
+++ b/main.nf
@@ -728,10 +728,11 @@ process bam_trim {
 
     output: 
     file "*.trimmed.bam" into ch_trimmed_bam_for_genotyping
+    file "*.bai"
 
     script:
     prefix="${bam.baseName}"
-    softclip = ${params.bamutils_softclip} ? '-c' : '' 
+    softclip = "${params.bamutils_softclip}" ? '-c' : '' 
     """
     bam trimBam $bam tmp.bam -L ${params.bamutils_clip_left} -R ${params.bamutils_clip_right} ${softclip}
     samtools sort -@ ${task.cpus} tmp.bam -o ${prefix}.trimmed.bam 

--- a/main.nf
+++ b/main.nf
@@ -116,6 +116,13 @@ params.pmdtools_threshold = 3
 params.pmdtools_reference_mask = ''
 params.pmdtools_max_reads = 10000
 
+//bamUtils trimbam settings
+params.trim_bam = false 
+params.bamutils_clip_left = 1 
+params.bamutils_clip_right = 1 
+params.bamutils_softclip = false 
+
+
 
 
 multiqc_config = file(params.multiqc_config)
@@ -661,10 +668,13 @@ process markDup{
 //If no deduplication runs, the input is mixed directly from samtools filter, if it runs either markdup or dedup is used thus mixed from these two channels
 ch_dedup_for_pmdtools = Channel.create()
 
+//Bamutils TrimBam Channel
+ch_for_bamutils = Channel.create()
+
 if(!params.skip_deduplication){
-    ch_dedup_for_pmdtools.mix(ch_markdup_bam,ch_dedup_bam).set {ch_for_pmdtools}
+    ch_dedup_for_pmdtools.mix(ch_markdup_bam,ch_dedup_bam).into {ch_for_pmdtools;ch_for_bamutils}
 } else {
-    ch_dedup_for_pmdtools.mix(ch_markdup_bam,ch_dedup_bam,ch_bam_filtered_pmdtools).set {ch_for_pmdtools}
+    ch_dedup_for_pmdtools.mix(ch_markdup_bam,ch_dedup_bam,ch_bam_filtered_pmdtools).into {ch_for_pmdtools;ch_for_bamutils}
 }
 
 if(!params.run_pmdtools){
@@ -702,7 +712,32 @@ process pmdtools {
     """
 }
 
-//Close Channel for pmdtools as it 
+/*
+* Optional BAM Trimming step using bamUtils 
+* Can be used for UDGhalf protocols to clip off -n bases of each read
+*/
+
+process bam_trim {
+    tag "${prefix}" 
+    publishDir "${params.outdir}/trimmed_bam", mode: 'copy'
+ 
+    when: params.trim_bam
+
+    input:
+    file bam from ch_for_bamutils  
+
+    output: 
+    file "*.trimmed.bam" into ch_trimmed_bam_for_genotyping
+
+    script:
+    prefix="${bam.baseName}"
+    softclip = ${params.bamutils_softclip} ? '-c' : '' 
+    """
+    bam trimBam $bam tmp.bam -L ${params.bamutils_clip_left} -R ${params.bamutils_clip_right} ${softclip}
+    samtools sort -@ ${task.cpus} tmp.bam -o ${prefix}.trimmed.bam 
+    samtools index ${prefix}.trimmed.bam
+    """
+}
 
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ params {
   //More defaults
   complexity_filter = false
   complexity_filter_poly_g_min = 10
+  trim_bam = false
 
   // AWS Batch
   awsqueue = false


### PR DESCRIPTION
This adds optional bam trimming for UDGhalf protocols for example. Users can specify how many bases should be clipped off reads at start/end after mapping and this will be done. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 