### PR TITLE
Adjustments for #76 , rename certain options to be more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [#80](https://github.com/nf-core/eager/pull/80) - BWA Index file handling 
 * [#77](https://github.com/nf-core/eager/pull/77) - Lots of documentation updates by [@jfy133](https://github.com/jfy133)
 
+### `Changed`
+* [#81](https://github.com/nf-core/eager/pull/81) - Renaming of certain BAM options
+
 ## [2.0.2] - 2018-11-03
 
 ### `Changed`

--- a/conf/binac.config
+++ b/conf/binac.config
@@ -10,7 +10,7 @@ singularity {
 }
 
 process {
-    beforeScript = 'module load devel/singularity/2.4.1'
+    beforeScript = 'module load devel/singularity/2.6.0'
     executor = 'pbs'
     queue = 'short'
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -387,9 +387,13 @@ Users can configure to keep/discard/extract certain groups of reads efficiently 
 
 This can be used to only keep mapped reads in the BAM file for downstream analysis. By default turned off, where all reads are kept in the bam file. Unmapped reads are stored both in BAM and FastQ format e.g. for different downstream processing.
 
+### `--bam_discard_unmapped_entirely`
+
+This discards all unmapped and extracted reads entirely. By default, this is turned off. 
+
 ### `--bam_keep_all`
 
-Turned on by default, keeps all reads that were mapped in the dataset. 
+Turned on by default, keeps all reads that were mapped in the dataset.
 
 ### `--bam_retain_all_reads`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -385,7 +385,7 @@ Users can configure to keep/discard/extract certain groups of reads efficiently 
 
 ### `--bam_analyse_mapped_only`
 
-This can be used to only keep mapped reads in the BAM file for downstream analysis. By default turned off, all reads are kept in the BAM file. Unmapped reads are stored both in BAM and FastQ format e.g. for different downstream processing.
+This can be used to only keep mapped reads in the BAM file for downstream analysis. By default turned off, where all reads are kept in the bam file. Unmapped reads are stored both in BAM and FastQ format e.g. for different downstream processing.
 
 ### `--bam_keep_all`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -383,21 +383,25 @@ Turn this on to utilize BWA Mem instead of `bwa aln` for alignment. Can be quite
 
 Users can configure to keep/discard/extract certain groups of reads efficiently in the nf-core/eager pipeline. 
 
-### `--bam_analyse_mapped_only`
+### `--bam_retain_unmapped`
 
-This can be used to only keep mapped reads in the BAM file for downstream analysis. By default turned off, where all reads are kept in the bam file. Unmapped reads are stored both in BAM and FastQ format e.g. for different downstream processing.
+Specify this to keep also unmapped reads in the BAM file. This is the default setting, only mapping quality filters are applied to all reads. 
 
-### `--bam_discard_unmapped_entirely`
+### `--bam_separate_unmapped`
 
-This discards all unmapped and extracted reads entirely. By default, this is turned off. 
+Separates the mapped and unmapepd reads, keeps only mapped reads in the BAM file for downstream analysis.
 
-### `--bam_keep_all`
+### `--bam_unmapped_to_fastq`
 
-Turned on by default, keeps all reads that were mapped in the dataset.
+Converted unmapped reads in BAM format to compressed FastQ format. 
 
-### `--bam_retain_all_reads`
+### `--bam_discard_unmapped`
 
-Specify this, if you want to filter reads for downstream analysis. This keeps all mapped and unmapped reads in the output, but allows for quality threshold filtering using `--bam_mapping_quality_threshold`.
+Discards unmapped reads in either FastQ or BAM format, depending on the choice of the `--bam_unmapped_rm_type`. 
+
+### `--bam_unmapped_rm_type`
+
+Defines which unmapped read format to discard, options available are `bam` or `fastq.gz`. By default, `fastq.gz` format will be kept and `bam` will be removed.
 
 ### `--bam_mapping_quality_threshold`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -383,17 +383,17 @@ Turn this on to utilize BWA Mem instead of `bwa aln` for alignment. Can be quite
 
 Users can configure to keep/discard/extract certain groups of reads efficiently in the nf-core/eager pipeline. 
 
-### `--bam_keep_mapped_only`
+### `--bam_analyse_mapped_only`
 
-This can be used to only keep mapped reads for downstream analysis. By default turned off, all reads are kept in the BAM file. Unmapped reads are stored both in BAM and FastQ format e.g. for different downstream processing.
+This can be used to only keep mapped reads in the BAM file for downstream analysis. By default turned off, all reads are kept in the BAM file. Unmapped reads are stored both in BAM and FastQ format e.g. for different downstream processing.
 
 ### `--bam_keep_all`
 
 Turned on by default, keeps all reads that were mapped in the dataset. 
 
-### `--bam_filter_reads`
+### `--bam_retain_all_reads`
 
-Specify this, if you want to filter reads for downstream analysis. 
+Specify this, if you want to filter reads for downstream analysis. This keeps all mapped and unmapped reads in the output, but allows for quality threshold filtering using `--bam_mapping_quality_threshold`.
 
 ### `--bam_mapping_quality_threshold`
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - bioconda::pmdtools=0.60
   - conda-forge::r-rmarkdown=1.10
   - conda-forge::libiconv=1.15
+  - conda-forge::pigz=2.3.4
   - bioconda::sequencetools=1.2.2
   - bioconda::preseq=2.0.3
   - bioconda::fastp=0.19.4

--- a/main.nf
+++ b/main.nf
@@ -721,7 +721,7 @@ process samtools_filter {
     prefix="$bam" - ~/(\.bam)?/
     rm_type = "${params.bam_unmapped_keep_type}" == 'bam' ? 'bam' : 'fastq'
     rm_unmapped = "${params.bam_discard_unmapped}" ? "rm *.unmapped.${rm_type}" : ''
-    fq_convert = "${params.bam_unmapped_to_fastq}" ? "samtools fastq -tn "${prefix}.unmapped.bam" | gzip > "${prefix}.unmapped.fq.gz"" : 
+    fq_convert = "${params.bam_unmapped_to_fastq}" ? "samtools fastq -tn ${prefix}.unmapped.bam | gzip > ${prefix}.unmapped.fq.gz" : ''
     
 
     if("${params.bam_separate_unmapped}"){
@@ -729,6 +729,7 @@ process samtools_filter {
         samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
         samtools index ${prefix}.filtered.bam
         $fq_convert
+        $rm_unmapped
         """
     } else {
         """

--- a/main.nf
+++ b/main.nf
@@ -76,8 +76,12 @@ def helpMessage() {
       --bwamem                      Turn on BWA Mem instead of CM/BWA aln for mapping
     
     BAM Filtering
-      --bam_retain_unmapped                Keep all reads in BAM file for downstream analysis
-      --bam_mapping_quality_threshold   Minimum mapping quality for reads filter
+      --bam_retain_unmapped         Retains all unmapped reads in the BAM file (default)
+      --bam_separate_unmapped       Separates mapped and unmapped reads, keep mapped BAM for downstream analysis.
+      --bam_unmapped_to_fastq       Converts unmapped reads in BAM format to fastq.gz format.
+      --bam_discard_unmapped        Discards unmapped reads in either FASTQ or BAM format, depending on choice in --bam_unmapped_rm_type
+      --bam_unmapped_rm_type        Defines which unmapped read format to discard, options are "bam" or "fastq.gz".
+      --bam_mapping_quality_threshold   Minimum mapping quality for reads filter, default 0.
     
     DeDuplication
       --dedupper                    Deduplication method to use
@@ -175,7 +179,7 @@ params.bwamem = false
 params.bam_retain_unmapped = false
 params.bam_discard_unmapped = false
 params.bam_unmapped_to_fastq = false 
-params.bam_unmapped_keep_type = 'bam'
+params.bam_unmapped_rm_type = 'bam'
 
 params.bam_mapping_quality_threshold = 0
 
@@ -719,7 +723,7 @@ process samtools_filter {
 
     script:
     prefix="$bam" - ~/(\.bam)?/
-    rm_type = "${params.bam_unmapped_keep_type}" == 'bam' ? 'bam' : 'fastq.gz'
+    rm_type = "${params.bam_unmapped_rm_type}" == 'bam' ? 'bam' : 'fastq.gz'
     rm_unmapped = "${params.bam_discard_unmapped}" ? "rm *.unmapped.${rm_type}" : ''
     fq_convert = "${params.bam_unmapped_to_fastq}" ? "samtools fastq -tn ${prefix}.unmapped.bam | pigz -p ${task.cpus} > ${prefix}.unmapped.fq.gz" : ''
     

--- a/main.nf
+++ b/main.nf
@@ -719,7 +719,7 @@ process samtools_filter {
 
     script:
     prefix="$bam" - ~/(\.bam)?/
-    rm_type = "${params.bam_unmapped_keep_type}" == 'bam' ? 'bam' : 'fastq'
+    rm_type = "${params.bam_unmapped_keep_type}" == 'bam' ? 'bam' : 'fastq.gz'
     rm_unmapped = "${params.bam_discard_unmapped}" ? "rm *.unmapped.${rm_type}" : ''
     fq_convert = "${params.bam_unmapped_to_fastq}" ? "samtools fastq -tn ${prefix}.unmapped.bam | gzip > ${prefix}.unmapped.fq.gz" : ''
     

--- a/main.nf
+++ b/main.nf
@@ -76,8 +76,8 @@ def helpMessage() {
       --bwamem                      Turn on BWA Mem instead of CM/BWA aln for mapping
     
     BAM Filtering
-      --bam_keep_mapped_only            Only consider mapped reads for downstream analysis. Unmapped reads are extracted to separate output.
-      --bam_filter_reads                Keep all reads in BAM file for downstream analysis
+      --bam_analyse_mapped_only         Only consider mapped reads for downstream analysis. Unmapped reads are extracted to separate output.
+      --bam_retain_all_reads                Keep all reads in BAM file for downstream analysis
       --bam_mapping_quality_threshold   Minimum mapping quality for reads filter
     
     DeDuplication
@@ -173,9 +173,9 @@ params.circularfilter = false
 params.bwamem = false
 
 //BAM Filtering steps (default = keep mapped and unmapped in BAM file)
-params.bam_keep_mapped_only = false
+params.bam_analyse_mapped_only = false
 params.bam_keep_all = true
-params.bam_filter_reads = false
+params.bam_retain_all_reads = false
 params.bam_mapping_quality_threshold = 0
 
 //DamageProfiler settings
@@ -715,12 +715,12 @@ process samtools_filter {
     file "*.unmapped.bam" optional true
     file "*.bai"
 
-    when: "${params.bam_filter_reads}"
+    when: "${params.bam_retain_all_reads}"
 
     script:
     prefix="$bam" - ~/(\.bam)?/
 
-    if("${params.bam_keep_mapped_only}"){
+    if("${params.bam_analyse_mapped_only}"){
     """
     samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
     samtools fastq -tn "${prefix}.unmapped.bam" | gzip > "${prefix}.unmapped.fq.gz"

--- a/main.nf
+++ b/main.nf
@@ -719,7 +719,7 @@ process samtools_filter {
 
     script:
     prefix="$bam" - ~/(\.bam)?/
-    rm_unmapped = params.params.bam_discard_unmapped_entirely ? 'rm *.unmapped.*' : ''
+    rm_unmapped = "${params.bam_discard_unmapped_entirely}" ? 'rm *.unmapped.*' : ''
 
     if("${params.bam_analyse_mapped_only}"){
     """

--- a/main.nf
+++ b/main.nf
@@ -176,7 +176,8 @@ params.circularfilter = false
 params.bwamem = false
 
 //BAM Filtering steps (default = keep mapped and unmapped in BAM file)
-params.bam_retain_unmapped = false
+params.bam_retain_unmapped = true
+params.bam_separate_unmapped = false
 params.bam_discard_unmapped = false
 params.bam_unmapped_to_fastq = false 
 params.bam_unmapped_rm_type = 'bam'

--- a/main.nf
+++ b/main.nf
@@ -719,8 +719,7 @@ process samtools_filter {
 
     script:
     prefix="$bam" - ~/(\.bam)?/
-    rm_unmapped=''
-    "${params.bam_discard_unmapped_entirely} ? rm_unmapped='rm *.unmapped.*' : ''
+    rm_unmapped = params.params.bam_discard_unmapped_entirely ? 'rm *.unmapped.*' : ''
 
     if("${params.bam_analyse_mapped_only}"){
     """

--- a/main.nf
+++ b/main.nf
@@ -719,12 +719,15 @@ process samtools_filter {
 
     script:
     prefix="$bam" - ~/(\.bam)?/
+    rm_unmapped=''
+    "${params.bam_discard_unmapped_entirely} ? rm_unmapped='rm *.unmapped.*' : ''
 
     if("${params.bam_analyse_mapped_only}"){
     """
     samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
     samtools fastq -tn "${prefix}.unmapped.bam" | gzip > "${prefix}.unmapped.fq.gz"
     samtools index -@ ${task.cpus} ${prefix}.filtered.bam
+    ${rm_unmapped}
     """
     } else {
     """

--- a/main.nf
+++ b/main.nf
@@ -721,7 +721,7 @@ process samtools_filter {
     prefix="$bam" - ~/(\.bam)?/
     rm_type = "${params.bam_unmapped_keep_type}" == 'bam' ? 'bam' : 'fastq.gz'
     rm_unmapped = "${params.bam_discard_unmapped}" ? "rm *.unmapped.${rm_type}" : ''
-    fq_convert = "${params.bam_unmapped_to_fastq}" ? "samtools fastq -tn ${prefix}.unmapped.bam | gzip > ${prefix}.unmapped.fq.gz" : ''
+    fq_convert = "${params.bam_unmapped_to_fastq}" ? "samtools fastq -tn ${prefix}.unmapped.bam | pigz -p ${task.cpus} > ${prefix}.unmapped.fq.gz" : ''
     
 
     if("${params.bam_separate_unmapped}"){

--- a/main.nf
+++ b/main.nf
@@ -76,8 +76,7 @@ def helpMessage() {
       --bwamem                      Turn on BWA Mem instead of CM/BWA aln for mapping
     
     BAM Filtering
-      --bam_analyse_mapped_only         Only consider mapped reads for downstream analysis. Unmapped reads are extracted to separate output.
-      --bam_retain_all_reads                Keep all reads in BAM file for downstream analysis
+      --bam_retain_unmapped                Keep all reads in BAM file for downstream analysis
       --bam_mapping_quality_threshold   Minimum mapping quality for reads filter
     
     DeDuplication
@@ -173,10 +172,13 @@ params.circularfilter = false
 params.bwamem = false
 
 //BAM Filtering steps (default = keep mapped and unmapped in BAM file)
-params.bam_analyse_mapped_only = false
-params.bam_keep_all = true
-params.bam_retain_all_reads = false
+params.bam_retain_unmapped = false
+params.bam_discard_unmapped = false
+params.bam_unmapped_to_fastq = false 
+params.bam_unmapped_keep_type = 'bam'
+
 params.bam_mapping_quality_threshold = 0
+
 
 //DamageProfiler settings
 params.damageprofiler_length = 100
@@ -715,23 +717,24 @@ process samtools_filter {
     file "*.unmapped.bam" optional true
     file "*.bai"
 
-    when: "${params.bam_retain_all_reads}"
-
     script:
     prefix="$bam" - ~/(\.bam)?/
-    rm_unmapped = "${params.bam_discard_unmapped_entirely}" ? 'rm *.unmapped.*' : ''
+    rm_type = "${params.bam_unmapped_keep_type}" == 'bam' ? 'bam' : 'fastq'
+    rm_unmapped = "${params.bam_discard_unmapped}" ? "rm *.unmapped.${rm_type}" : ''
+    fq_convert = "${params.bam_unmapped_to_fastq}" ? "samtools fastq -tn "${prefix}.unmapped.bam" | gzip > "${prefix}.unmapped.fq.gz"" : 
+    
 
-    if("${params.bam_analyse_mapped_only}"){
-    """
-    samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
-    samtools fastq -tn "${prefix}.unmapped.bam" | gzip > "${prefix}.unmapped.fq.gz"
-    samtools index ${prefix}.filtered.bam
-    """
+    if("${params.bam_separate_unmapped}"){
+        """
+        samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
+        samtools index ${prefix}.filtered.bam
+        $fq_convert
+        """
     } else {
-    """
-    samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
-    samtools index ${prefix}.filtered.bam
-    """
+        """
+        samtools view -h $bam -@ ${task.cpus} -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
+        samtools index ${prefix}.filtered.bam
+        """
     }  
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,6 +27,7 @@ params {
   complexity_filter = false
   complexity_filter_poly_g_min = 10
   trim_bam = false
+  bam_discard_unmapped_entirely = false
 
   // AWS Batch
   awsqueue = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,6 @@ params {
   complexity_filter = false
   complexity_filter_poly_g_min = 10
   trim_bam = false
-  bam_discard_unmapped_entirely = false
 
   // AWS Batch
   awsqueue = false


### PR DESCRIPTION
This renames a couple of things to different names, to make sure people understand what these options mean. 

cf https://github.com/nf-core/eager/issues/76 

Namely:

bam_keep_mapped_only ==> bam_analyse_mapped_only

bam_filter_reads ==> bam_retain_all_reads


 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated


**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
