### PR TITLE
Rename reference to fasta in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Added`
 * [#127](https://github.com/nf-core/eager/pull/127) - Added a second testcase for testing the pipeline properly
 * [#129](https://github.com/nf-core/eager/pull/129) - Support BAM files as [input format](https://github.com/nf-core/eager/issues/41)
+* [#131](https://github.com/nf-core/eager/pull/131) - Support different [reference genome file extensions](https://github.com/nf-core/eager/issues/130)
 
 ### `Fixed`
 * [#128](https://github.com/nf-core/eager/issues/128) - Fixed reference genome handling errors

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,7 +168,7 @@ If you prefer, you can specify the full path to your reference genome when you r
 ```bash
 --fasta '[path to Fasta reference]'
 ```
-> If you don't specify appropriate `--bwa_index`, `--fasta_index` parameters, the pipeline will create these indices for you automatically. Note, that saving these for later has to be turned on using `--saveReference`. You may also specify the path to a gzipped (`*.gz` file extension) FastA as reference genome - this will be uncompressed by the pipeline automatically for you.
+> If you don't specify appropriate `--bwa_index`, `--fasta_index` parameters, the pipeline will create these indices for you automatically. Note, that saving these for later has to be turned on using `--saveReference`. You may also specify the path to a gzipped (`*.gz` file extension) FastA as reference genome - this will be uncompressed by the pipeline automatically for you. Note that other file extensions such as `.fna`, `.fa` are also supported but will be renamed to `.fasta` automatically by the pipeline.
 
 ### `--genome` (using iGenomes)
 

--- a/main.nf
+++ b/main.nf
@@ -417,11 +417,12 @@ process makeBWAIndex {
     file "where_are_my_files.txt"
 
     script:
+    base = "${fasta.baseName}"
     """
     mkdir bwa_index
-    cp "${fasta}" bwa_index/
+    mv "${fasta}" "bwa_index/${base}.fasta"
     cd bwa_index
-    bwa index $fasta
+    bwa index "${base}.fasta"
     """
 }
 
@@ -445,13 +446,17 @@ process makeFastaIndex {
     file wherearemyfiles from ch_where_for_fasta_index
 
     output:
-    file "${fasta}.fai" into ch_fasta_faidx_index
-    file "${fasta}"
+    file "faidx/${base}.fasta.fai" into ch_fasta_faidx_index
+    file "faidx/${base}.fasta"
     file "where_are_my_files.txt"
 
     script:
+    base = "${fasta.baseName}"
     """
-    samtools faidx $fasta
+    mkdir faidx
+    mv $fasta "faidx/${base}.fasta"
+    cd faidx
+    samtools faidx "${base}.fasta"
     """
 }
 
@@ -475,12 +480,16 @@ process makeSeqDict {
     file wherearemyfiles from ch_where_for_seqdict
 
     output:
-    file "*.dict" into ch_seq_dict
+    file "seq_dict/*.dict" into ch_seq_dict
     file "where_are_my_files.txt"
 
     script:
+    base = "${fasta.baseName}.fasta"
     """
-    picard CreateSequenceDictionary R=$fasta O="${fasta.baseName}.dict"
+    mkdir -p seq_dict
+    mv $fasta "seq_dict/${base}"
+    cd seq_dict
+    picard CreateSequenceDictionary R=$base O="${fasta.baseName}.dict"
     """
 }
 


### PR DESCRIPTION
This should address the error in #130 and your issues @jfy133 :-) 

Automatically renames any `--fasta` reference genome to use the `*.fasta` file extension if its not present already 👍 