### PR TITLE
Bugfix for Damageprofiler, also new deps adding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Added`
 
 ### `Fixed`
-
+* [#172](https://github.com/nf-core/eager/pull/152) - DamageProfiler errors [won't crash entire pipeline anymore](https://github.com/nf-core/eager/issues/171)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unpublished Version / DEV]
+
+### `Added`
+
+### `Fixed`
+
+### `Dependencies`
+
+* Added DeDup v0.12.4 (json support)
+* Added mtnucratio v0.5 (json support)
+
+
 ## [2.0.6] - 2019-03-05
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 
+
 ### `Dependencies`
 
 * Added DeDup v0.12.4 (json support)

--- a/conf/base.config
+++ b/conf/base.config
@@ -25,7 +25,6 @@ process {
   withName:get_software_versions {
     memory = { check_max( 2.GB, 'memory' ) }
     cache = false
-    //errorStrategy = 'ignore'
   }
   
   withName:convertBam {
@@ -62,6 +61,10 @@ process {
   }
   withName: multiqc {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
+
+  withName: damageprofiler {
+    errorStrategy = 'ignore'
   }
 }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -46,6 +46,7 @@ process {
   }
   withName:qualimap{
     cpus = { check_max(8 * task.attempt, 'cpus') }
+    errorStrategy = 'ignore'
   }
   withName:bam_trim{
     cpus = { check_max(4 * task.attempt, 'cpus') }

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - bioconda::bwa=0.7.17
   - bioconda::picard=2.18.27
   - bioconda::samtools=1.9
-  - bioconda::dedup=0.12.4
+  - bioconda::dedup=0.12.5
   - bioconda::angsd=0.923
   - bioconda::circularmapper=1.93.4
   - bioconda::gatk4=4.1.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - bioconda::bwa=0.7.17
   - bioconda::picard=2.18.27
   - bioconda::samtools=1.9
-  - bioconda::dedup=0.12.3
+  - bioconda::dedup=0.12.4
   - bioconda::angsd=0.923
   - bioconda::circularmapper=1.93.4
   - bioconda::gatk4=4.1.0.0
@@ -27,4 +27,5 @@ dependencies:
   - bioconda::preseq=2.0.3
   - bioconda::fastp=0.19.7
   - bioconda::bamutil=1.0.14
+  - bioconda::mtnucratio=0.5
   #Missing Schmutzi,snpAD


### PR DESCRIPTION
- Adds in a fix for damageprofiler when output is too small to show even results
- Adds mtnucratio and dedup recipes to get new JSON output for future multiqc reporting ;-) 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
