### PR TITLE
fixed multiqc config too-strict post-AR path

### DIFF
--- a/conf/multiqc_config.yaml
+++ b/conf/multiqc_config.yaml
@@ -14,7 +14,7 @@ top_modules:
      - 'fastqc':
          name: 'FastQC (post-AdapterRemoval)'
          path_filters:
-             - '*.combined.prefixed_fastqc.zip'
+             - '*.combined*_fastqc.zip'
      - 'samtools'
      - 'preseq'
      - 'dedup'


### PR DESCRIPTION
The path originally used failed to picked up FastQC files if you had e.g. performed polyG trimming. The new regex now picks up any FastQC file that has 'combined' in the name. This still isn't perfect but we can fix it once the new prefix system is in. 

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
