### PR TITLE
Added post-mapping filter statistics generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Merged in [nf-core/tools](https://github.com/nf-core/tools) release V1.6 template changes  
 * A lot more automated tests using Travis CI
 * Don't ignore DamageProfiler errors anymore 
+* Added post-mapping filtering statistics module and corresponding MultiQC statistics [#217](https://github.com/nf-core/eager/issues/217)
 
 ### `Fixed`
 * [#152](https://github.com/nf-core/eager/pull/152) - DamageProfiler errors [won't crash entire pipeline anymore](https://github.com/nf-core/eager/issues/171)

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -50,6 +50,10 @@ table_columns_visible:
         percent_duplicates: False
         total_sequences: True
         percent_gc: True
+    Samtools Flagstat (pre-samtools filter):
+        mapped_passed: True
+    Samtools Flagstat (post-samtools filter):
+        mapped_passed: True
     QualiMap:
         1_x_pc: True
         5_x_pc: True

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -10,18 +10,18 @@ top_modules:
      - 'fastp'
      - 'adapterRemoval'
      - 'fastqc':
-         name: 'FastQC (post-AdapterRemoval)'
-         path_filters:
-             - '*.truncated_fastqc.zip'
-             - '*.combined*_fastqc.zip'
+        name: 'FastQC (post-AdapterRemoval)'
+        path_filters:
+            - '*.truncated_fastqc.zip'
+            - '*.combined*_fastqc.zip'
      - 'samtools':
-	 name: 'Samtools Flagstat (pre-samtools filter)'
-	 path_filters: 
-		- '*.sorted.stats'
+    	name: 'Samtools Flagstat (pre-samtools filter)'
+    	path_filters:
+		     - '*.sorted.stats'
      - 'samtools':
-	 name: 'Samtools Flagstat (post-samtools filter)'
-	 path_filters:
-	     - '*.sorted.bam.filtered.stats'
+	    name: 'Samtools Flagstat (post-samtools filter)'
+	    path_filters:
+	         - '*.sorted.bam.filtered.stats'
      - 'dedup'
      - 'preseq'
      - 'qualimap'
@@ -54,7 +54,7 @@ table_columns_visible:
         1_x_pc: True
         5_x_pc: True
         percentage_aligned: False
-    DamageProfiler::
+    DamageProfiler:
         3 Prime1: True
         3 Prime2: True
         5 Prime1: True
@@ -78,7 +78,7 @@ table_columns_placement:
         mapped_passed: 500
     Samtools Flagstat (post-samtools filter):
         mapped_passed: 510
-    DeDup: 
+    DeDup:
         clusterfactor: 600        
         duplication_rate: 610
     QualiMap:
@@ -93,7 +93,7 @@ table_columns_placement:
         mtreads: 800
         mt_cov_avg: 810
         mt_nuc_ratio: 820
-    DamageProfiler::
+    DamageProfiler:
         3 Prime1: 900
         3 Prime2: 910
         5 Prime1: 920

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -15,13 +15,13 @@ top_modules:
             - '*.truncated_fastqc.zip'
             - '*.combined*_fastqc.zip'
      - 'samtools':
-    	name: 'Samtools Flagstat (pre-samtools filter)'
-    	path_filters:
-		     - '*.sorted.stats'
+        name: 'Samtools Flagstat (pre-samtools filter)'
+        path_filters:
+             - '*.sorted.stats'
      - 'samtools':
-	    name: 'Samtools Flagstat (post-samtools filter)'
-	    path_filters:
-	         - '*.sorted.bam.filtered.stats'
+        name: 'Samtools Flagstat (post-samtools filter)'
+        path_filters:
+             - '*.sorted.bam.filtered.stats'
      - 'dedup'
      - 'preseq'
      - 'qualimap'

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -14,7 +14,14 @@ top_modules:
          path_filters:
              - '*.truncated_fastqc.zip'
              - '*.combined*_fastqc.zip'
-     - 'samtools'
+     - 'samtools':
+	 name: 'Samtools Flagstat (pre-samtools filter)'
+	 path_filters: 
+		- '*.sorted.stats'
+     - 'samtools':
+	 name: 'Samtools Flagstat (post-samtools filter)'
+	 path_filters:
+	     - '*.sorted.bam.filtered.stats'
      - 'dedup'
      - 'preseq'
      - 'qualimap'
@@ -67,8 +74,10 @@ table_columns_placement:
         total_sequences: 400
         avg_sequence_length: 410
         percent_gc: 420
-    Samtools Flagstat:
+    Samtools Flagstat (pre-samtools filter):
         mapped_passed: 500
+    Samtools Flagstat (post-samtools filter):
+        mapped_passed: 510
     DeDup: 
         clusterfactor: 600        
         duplication_rate: 610

--- a/docs/output.md
+++ b/docs/output.md
@@ -72,6 +72,7 @@ The default columns are as follows:
   * **Seqs** This is from Post-AdapterRemoval FastQC. Represents the number of preprocessed reads in your adapter trimmed (paired end) merged FASTQ file. The loss between this number and the Pre-AdapterRemoval FastQC can give you an idea of the quality of trimming and merging.
   * **%GC** This is from Post-AdapterRemoval FastQC. Represents the average GC of all preprocessed reads in your adapter trimmed (paired end) merged FASTQ file.
   * **Reads Mapped** This is from Samtools. This is the raw number of preprocessed reads mapped to your reference genome _prior_ map quality filtering and deduplication.
+  * **Reads Mapped** This is from Samtools. This is the raw number of preprocessed reads mapped to your reference genome _after_ map quality filtering and deduplication (note the column name does not distinguish itself from prior-map quality filtering, but the post-filter column is always second)
   * **Duplication Rate** This is from DeDup. This is the percentage of overall number of mapped reads that were an exact duplicate of another read. The number of reads removed by DeDup can be calculating this number by mapped reads (if no map quality filtering was applied!)
   * **Coverage** This is from Qualimap. This is the median number of times a base on your reference genome was covered by a read (i.e. depth coverage).. This average includes bases with 0 reads covering that position.
   * **>= 1X** to **>= 5X** These are from Qualimap. This is the percentage of the genome covered at that particular depth coverage.
@@ -232,6 +233,9 @@ In most cases the first two rows, 'Total Reads' and 'Total Passed QC' will be th
 The third row 'Mapped' represents the number of reads that found a place that could be aligned on your reference genome. This is the raw number of mapped reads, prior PCR duplication.
 
 The remaining rows will be 0 when running `bwa aln` as these characteristucs of the data are not considered by the algorithm by default.
+
+> **NB:** The Samtools (pre-samtools filter) plots displayed in the MultiQC report shows mapped reads without mapping quality filtering. This will contain reads that can map to multiple places on your reference genome with equal or slightly less mapping quality score. To see how your reads look after mapping quality, look at the FastQC reports in the Samtools (pre-samtools filter). You should expect after mapping quality filtering, that you will have less reads.
+
 
 ### DeDup
 #### Background

--- a/main.nf
+++ b/main.nf
@@ -972,7 +972,7 @@ process samtools_flagstat_after_filter {
     file(bam) from ch_bam_filtered_flagstat
 
     output:
-    file "*.stats" into ch_filtered_flagstat_for_multiqc
+    file "*.stats" into ch_bam_filtered_flagstat_for_multiqc
 
     script:
     prefix = "$bam" - ~/(\.bam)?$/
@@ -1305,7 +1305,7 @@ process multiqc {
     file ('software_versions/software_versions_mqc*') from software_versions_yaml.collect().ifEmpty([])
     file ('adapter_removal/*') from ch_adapterremoval_logs.collect().ifEmpty([])
     file ('flagstat/*') from ch_flagstat_for_multiqc.collect().ifEmpty([])
-    file ('flagstat_filtered') from ch_filtered_flagstat_for_multiqc.collect().ifEmpty([])
+    file ('flagstat_filtered/*') from ch_bam_filtered_flagstat_for_multiqc.collect().ifEmpty([])
     file ('preseq/*') from ch_preseq_results.collect().ifEmpty([])
     file ('damageprofiler/dmgprof*/*') from ch_damageprofiler_results.collect().ifEmpty([])
     file ('qualimap/qualimap*/*') from ch_qualimap_results.collect().ifEmpty([])

--- a/main.nf
+++ b/main.nf
@@ -969,7 +969,7 @@ process samtools_idxstats_after_filter {
     publishDir "${params.outdir}/samtools/stats", mode: 'copy'
 
     input:
-    file(bam) from ch_bam_filtered_idxstats)
+    file(bam) from ch_mapped_reads_filtered_idxstats.mix(ch_mapped_reads_filtered_idxstats)
 
     output:
     file "*.stats" into ch_filtered_idxstats_for_multiqc

--- a/main.nf
+++ b/main.nf
@@ -443,7 +443,7 @@ ${summary.collect { k,v -> "            <dt>$k</dt><dd><samp>${v ?: '<span style
 
 
 /* 
-* Create BWA indices if they are not present
+* PREPROCESSING - Create BWA indices if they are not present
 */ 
 
 if(!params.bwa_index && !params.fasta.isEmpty() && (params.aligner == 'bwa' || params.bwamem)){
@@ -528,7 +528,7 @@ process makeSeqDict {
 }
 
 /*
-* Convert BAM to FastQ if BAM input is specified instead of FastQ file(s)
+* PREPROCESSING - Convert BAM to FastQ if BAM input is specified instead of FastQ file(s)
 *
 */ 
 
@@ -554,7 +554,7 @@ process convertBam {
 
 
 /*
- * STEP 1 - FastQC
+ * STEP 1a - FastQC
  */
 process fastqc {
     tag "$name"
@@ -578,7 +578,7 @@ process fastqc {
 }
 
 
-/* STEP 2.0 - FastP
+/* STEP 1b - FastP
 * Optional poly-G complexity filtering step before read merging/adapter clipping etc
 * Note: Clipping, Merging, Quality Trimning are turned off here - we leave this to adapter removal itself!
 */
@@ -676,7 +676,7 @@ process adapter_removal {
 
 
 /*
-* STEP 2.1 - FastQC after clipping/merging (if applied!)
+* STEP 2b - FastQC after clipping/merging (if applied!)
 */
 process fastqc_after_clipping {
     tag "${name}"
@@ -698,7 +698,7 @@ process fastqc_after_clipping {
 }
 
 /*
-Step 3: Mapping with BWA, SAM to BAM, Sort BAM
+Step 3a  - Mapping with BWA, SAM to BAM, Sort BAM
 */
 
 process bwa {
@@ -848,7 +848,7 @@ process bwamem {
 }
 
 /*
-* Step 4 - flagstat
+* Step 3b - flagstat
 */
 
 process samtools_flagstat {
@@ -870,7 +870,7 @@ process samtools_flagstat {
 
 
 /*
-* Step 5: Keep unmapped/remove unmapped reads
+* Step 4a - Keep unmapped/remove unmapped reads
 */
 
 process samtools_filter {
@@ -960,7 +960,7 @@ process strip_input_fastq {
 }
 
 /*
-* Step 5b: Keep unmapped/remove unmapped reads flagstat
+* Step 4b: Keep unmapped/remove unmapped reads flagstat
 */
 
 
@@ -983,7 +983,7 @@ process samtools_flagstat_after_filter {
 
 
 /*
-Step 6: DeDup / MarkDuplicates
+Step 5a: DeDup / MarkDuplicates
 */ 
 
 process dedup{
@@ -1026,7 +1026,7 @@ process dedup{
 }
 
 /*
-Step 5.1: Preseq
+Step 6: Preseq
 */
 
 process preseq {
@@ -1056,7 +1056,7 @@ process preseq {
 }
 
 /*
-Step 5.2: DMG Assessment
+Step 7a: DMG Assessment
 */ 
 
 process damageprofiler {
@@ -1084,7 +1084,7 @@ process damageprofiler {
 }
 
 /* 
-Step 5.3: Qualimap
+Step 8: Qualimap
 */
 
 process qualimap {
@@ -1112,7 +1112,7 @@ process qualimap {
 
 
 /*
- Step 6: MarkDuplicates
+ Step 5b: MarkDuplicates
  */
 
 process markDup{
@@ -1152,6 +1152,10 @@ if(!params.run_pmdtools){
     ch_dedup_for_pmdtools.close()
 }
 
+/*
+ Step 9: PMDtools
+ */
+
 process pmdtools {
     tag "${bam.baseName}"
     publishDir "${params.outdir}/pmdtools", mode: 'copy'
@@ -1184,7 +1188,7 @@ process pmdtools {
 }
 
 /*
-* Optional BAM Trimming step using bamUtils 
+* Step 10 - BAM Trimming step using bamUtils 
 * Can be used for UDGhalf protocols to clip off -n bases of each read
 */
 
@@ -1239,7 +1243,7 @@ Downstream VCF tools:
 
 
 /*
- * STEP 3 - Output Description HTML
+ * Step 11a - Output Description HTML
  */
 process output_documentation {
     publishDir "${params.outdir}/Documentation", mode: 'copy'
@@ -1258,7 +1262,7 @@ process output_documentation {
 
 
 /*
- * Parse software version numbers
+ * Step 11b - Parse software version numbers
  */
 process get_software_versions {
 
@@ -1293,7 +1297,7 @@ process get_software_versions {
 
 
 /*
- * STEP 2 - MultiQC
+ * Step 11c - MultiQC
  */
 process multiqc {
     publishDir "${params.outdir}/MultiQC", mode: 'copy'
@@ -1331,7 +1335,7 @@ process multiqc {
 
 
 /*
- * Completion e-mail notification
+ * Step 11d - Completion e-mail notification
  */
 workflow.onComplete {
 

--- a/main.nf
+++ b/main.nf
@@ -969,7 +969,7 @@ process samtools_idxstats_after_filter {
     publishDir "${params.outdir}/samtools/stats", mode: 'copy'
 
     input:
-    file(bam) from ch_bam_filtered_idxstats.mix(ch_bam_filtered_idxstats)
+    file(bam) from ch_bam_filtered_idxstats
 
     output:
     file "*.stats" into ch_filtered_idxstats_for_multiqc

--- a/main.nf
+++ b/main.nf
@@ -969,7 +969,7 @@ process samtools_idxstats_after_filter {
     publishDir "${params.outdir}/samtools/stats", mode: 'copy'
 
     input:
-    file(bam) from ch_mapped_reads_filtered_idxstats.mix(ch_mapped_reads_filtered_idxstats)
+    file(bam) from ch_bam_filtered_idxstats.mix(ch_bam_filtered_idxstats)
 
     output:
     file "*.stats" into ch_filtered_idxstats_for_multiqc


### PR DESCRIPTION
This PR duplicates the samtools flagstat step for after mapping quality filtering. This allows a user to see the effect of mapping quality filtering.

It also includes some clean-up of code comments

Note: I've manually tested this  myself. The only thing that is slightly off is that the General Stats table doesn't report the name of which samtools flagstat step it is from (but it displayes pre- and post- map quality filtering in the correct order). However the menu on the left does have the correct names.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
