### PR TITLE
Adapter removal updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ script:
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --skip_collapse --saveReference
   # Run the basic pipeline with paired end data without trimming
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --skip_trim --saveReference
+  # Run the basic pipeline with preserve5p end option
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --preserve5p
    # Run the basic pipeline with paired end data without adapterRemoval
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --skip_adapterremoval --saveReference
    # Run the basic pipeline with output unmapped reads as fastq

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,10 @@ script:
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --skip_trim --saveReference
   # Run the basic pipeline with preserve5p end option
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --preserve5p
+    # Run the basic pipeline with preserve5p end option
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --mergedonly
+    # Run the basic pipeline with preserve5p end and merged reads only options
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --preserve5p --mergedonly
    # Run the basic pipeline with paired end data without adapterRemoval
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pairedEnd --skip_adapterremoval --saveReference
    # Run the basic pipeline with output unmapped reads as fastq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Added`
 
 * Added Support for automated tests using [GitHub Actions](https://github.com/features/actions)
-* Added genotyping capability through GATK UnifiedGenotyper (v3.5), GATK HaplotypeCaller (v4.1) and FreeBayes
+*  [#40](https://github.com/nf-core/eager/issues/40), [#231](https://github.com/nf-core/eager/issues/231) - Added genotyping capability through GATK UnifiedGenotyper (v3.5), GATK HaplotypeCaller (v4.1) and FreeBayes
 * Added MultiVCFAnalyzer module
-* Added human sex determination module.
+* [#240](https://github.com/nf-core/eager/issues/240) - Added human sex determination module.
+* [#226](https://github.com/nf-core/eager/issues/226) Added `--preserve5p` function for AdapterRemoval
 
 ### `Fixed`
 
@@ -33,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Added`
 
-* [#189](https://github.com/nf-core/eager/pull/189) - Outputing unmapped reads in a fastq files with the --strip_input_fastq flag
+* [#189](https://github.com/nf-core/eager/pull/189) - Outputting unmapped reads in a fastq files with the --strip_input_fastq flag
 * [#186](https://github.com/nf-core/eager/pull/186) - Make FastQC skipping [possible](https://github.com/nf-core/eager/issues/182)
 * Merged in [nf-core/tools](https://github.com/nf-core/tools) release V1.6 template changes  
 * A lot more automated tests using Travis CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 *  [#40](https://github.com/nf-core/eager/issues/40), [#231](https://github.com/nf-core/eager/issues/231) - Added genotyping capability through GATK UnifiedGenotyper (v3.5), GATK HaplotypeCaller (v4.1) and FreeBayes
 * Added MultiVCFAnalyzer module
 * [#240](https://github.com/nf-core/eager/issues/240) - Added human sex determination module.
-* [#226](https://github.com/nf-core/eager/issues/226) Added `--preserve5p` function for AdapterRemoval
+* [#226](https://github.com/nf-core/eager/issues/226) - Added `--preserve5p` function for AdapterRemoval
+* [#212](https://github.com/nf-core/eager/issues/212) - Added ability to use only mergedreads downstream from Adapterremoval
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Added`
 
 * Added Support for automated tests using [GitHub Actions](https://github.com/features/actions)
-*  [#40](https://github.com/nf-core/eager/issues/40), [#231](https://github.com/nf-core/eager/issues/231) - Added genotyping capability through GATK UnifiedGenotyper (v3.5), GATK HaplotypeCaller (v4.1) and FreeBayes
+* [#40](https://github.com/nf-core/eager/issues/40), [#231](https://github.com/nf-core/eager/issues/231) - Added genotyping capability through GATK UnifiedGenotyper (v3.5), GATK HaplotypeCaller (v4.1) and FreeBayes
 * Added MultiVCFAnalyzer module
 * [#240](https://github.com/nf-core/eager/issues/240) - Added human sex determination module.
 * [#226](https://github.com/nf-core/eager/issues/226) - Added `--preserve5p` function for AdapterRemoval

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -457,7 +457,7 @@ For example:
 
 ### `--preserve5p`
 
-Turns off quality based trimming at the 5p end of reads when any of the --trimns, --trimqualities, or --trimwindows options are used. Only 3p end of reads will be removed. 
+Turns off quality based trimming at the 5p end of reads when any of the --trimns, --trimqualities, or --trimwindows options are used. Only 3p end of reads will be removed.
 
 > This also entirely disables quality based trimming of collapsed reads, since both ends of these are informative for PCR duplicate filtering. Described [here](https://github.com/MikkelSchubert/adapterremoval/issues/32#issuecomment-504758137).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -457,9 +457,13 @@ For example:
 
 ### `--preserve5p`
 
- Turns off quality based trimming at the 5p end of reads when any of the --trimns, --trimqualities, or --trimwindows options are used. Only 3p end of reads will be removed. 
+Turns off quality based trimming at the 5p end of reads when any of the --trimns, --trimqualities, or --trimwindows options are used. Only 3p end of reads will be removed. 
 
- > This also entirely disables quality based trimming of collapsed reads, since both ends of these are informative for PCR duplicate filtering. Described [here](https://github.com/MikkelSchubert/adapterremoval/issues/32#issuecomment-504758137).
+> This also entirely disables quality based trimming of collapsed reads, since both ends of these are informative for PCR duplicate filtering. Described [here](https://github.com/MikkelSchubert/adapterremoval/issues/32#issuecomment-504758137).
+
+### `--mergedonly`
+
+This flag means that only merged reads are sent downstream for analysis. Singletons (i.e. reads missing a pair), or unmerged reads (where there wasn't sufficient overlap) are discarded. You may want to use this if you want ensure only the best quality reads for your analysis, but with the penalty of potentially losing still valid data (even if some reads have slightly lower quality).
 
 ## Read Mapping Parameters
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -455,6 +455,12 @@ For example:
 --pairedEnd --skip_trim  --reads '*.fastq'
 ```
 
+### `--preserve5p`
+
+ Turns off quality based trimming at the 5p end of reads when any of the --trimns, --trimqualities, or --trimwindows options are used. Only 3p end of reads will be removed. 
+
+ > This also entirely disables quality based trimming of collapsed reads, since both ends of these are informative for PCR duplicate filtering. Described [here](https://github.com/MikkelSchubert/adapterremoval/issues/32#issuecomment-504758137).
+
 ## Read Mapping Parameters
 
 ## `--mapper`

--- a/main.nf
+++ b/main.nf
@@ -62,13 +62,14 @@ def helpMessage() {
       --complexity_filter_poly_g_min    Specify length of poly-g min for clipping to be performed (default: 10)
     
     Clipping / Merging
-      --clip_forward_adaptor        Specify adapter sequence to be clipped off (forward)
-      --clip_reverse_adaptor        Specify adapter sequence to be clipped off (reverse)
-      --clip_readlength             Specify read minimum length to be kept for downstream analysis
-      --clip_min_read_quality       Specify minimum base quality for not trimming off bases
-      --min_adap_overlap            Specify minimum adapter overlap
+      --clip_forward_adaptor        Specify adapter sequence to be clipped off (forward). Default: 'AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC'
+      --clip_reverse_adaptor        Specify adapter sequence to be clipped off (reverse). Default: 'AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTA'
+      --clip_readlength             Specify read minimum length to be kept for downstream analysis. Default: 30
+      --clip_min_read_quality       Specify minimum base quality for trimming off bases. Default: 20 
+      --min_adap_overlap            Specify minimum adapter overlap: 1
       --skip_collapse               Skip merging forward and reverse reads together. (Only for PE samples)
       --skip_trim                   Skip adaptor and quality trimming
+      --preserve5p                  Skip 5p quality base trimming (n, score, window) at 5p end.
     
     Mapping
       --mapper                      Specify which mapper to use. Options: 'bwaaln', 'bwamem', 'circularmapper'. Default: 'bwaaln'
@@ -212,6 +213,7 @@ params.clip_min_read_quality = 20
 params.min_adap_overlap = 1
 params.skip_collapse = false
 params.skip_trim = false
+params.preserve5p = false
 
 //Mapping algorithm
 params.mapper = 'bwaaln'
@@ -812,21 +814,28 @@ process adapter_removal {
     //This checks whether we skip trimming and defines a variable respectively
     trim_me = params.skip_trim ? '' : "--trimns --trimqualities --adapter1 ${params.clip_forward_adaptor} --adapter2 ${params.clip_reverse_adaptor} --minlength ${params.clip_readlength} --minquality ${params.clip_min_read_quality} --minadapteroverlap ${params.min_adap_overlap}"
     collapse_me = params.skip_collapse ? '' : '--collapse'
+    preserve5p = params.preserve5p ? '--preserve5p' : ''
     
     //PE mode, dependent on trim_me and collapse_me the respective procedure is run or not :-) 
     if (!params.singleEnd && !params.skip_collapse && !params.skip_trim){
     """
     mkdir -p output
-    AdapterRemoval --file1 ${reads[0]} --file2 ${reads[1]} --basename ${base} ${trim_me} --gzip --threads ${task.cpus} ${collapse_me}
+    AdapterRemoval --file1 ${reads[0]} --file2 ${reads[1]} --basename ${base} ${trim_me} --gzip --threads ${task.cpus} ${collapse_me} ${preserve5p}
+    
     #Combine files
-    zcat *.collapsed.gz *.collapsed.truncated.gz *.singleton.truncated.gz *.pair1.truncated.gz *.pair2.truncated.gz | gzip > output/${base}.combined.fq.gz
+    if [ ${preserve5p}  = "--preserve5p" ]; then 
+      zcat *.collapsed.gz *.singleton.truncated.gz *.pair1.truncated.gz *.pair2.truncated.gz | gzip > output/${base}.combined.fq.gz
+    else
+      zcat *.collapsed.gz *.collapsed.truncated.gz *.singleton.truncated.gz *.pair1.truncated.gz *.pair2.truncated.gz | gzip > output/${base}.combined.fq.gz
+    fi
+   
     mv *.settings output/
     """
     //PE, don't collapse, but trim reads
     } else if (!params.singleEnd && params.skip_collapse && !params.skip_trim) {
     """
     mkdir -p output
-    AdapterRemoval --file1 ${reads[0]} --file2 ${reads[1]} --basename ${base} --gzip --threads ${task.cpus} ${trim_me} ${collapse_me}
+    AdapterRemoval --file1 ${reads[0]} --file2 ${reads[1]} --basename ${base} --gzip --threads ${task.cpus} ${trim_me} ${collapse_me} ${preserve5p}
     mv *.settings ${base}.pair*.truncated.gz output/
     """
     //PE, collapse, but don't trim reads
@@ -841,7 +850,7 @@ process adapter_removal {
     //SE, collapse not possible, trim reads
     """
     mkdir -p output
-    AdapterRemoval --file1 ${reads[0]} --basename ${base} --gzip --threads ${task.cpus} ${trim_me}
+    AdapterRemoval --file1 ${reads[0]} --basename ${base} --gzip --threads ${task.cpus} ${trim_me} ${preserve5p}
     
     mv *.settings *.truncated.gz output/
     """


### PR DESCRIPTION
This extends options for AdapterRemoval, namely:

1) preserve 5p (doesn't do quality trimmed at generally higher quality 5p ends, to prevent issues during deduplication) https://github.com/nf-core/eager/issues/226
2) use only merged reads downstream from AdapterRemoval for higher quality e.g. genotyping https://github.com/nf-core/eager/issues/212

@apeltzer the linting fails for [#5](http://nf-co.re/errors#5) but I'm not sure why because the line it refers to is in `.travis.yml`. Any ideas?

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
