### PR TITLE
Tweaking markdown linting to allow doc image justification

### DIFF
--- a/.github/markdownlint.yml
+++ b/.github/markdownlint.yml
@@ -3,3 +3,7 @@ default: true,
 line-length: false
 no-duplicate-header:
     siblings_only: true
+no-inline-html: 
+    allowed_elements:
+        - img
+        - p

--- a/docs/output.md
+++ b/docs/output.md
@@ -109,7 +109,7 @@ This shows a barplot with the overall number of sequences (x axis) in your raw l
 A section of the bar will also show an approximate estimation of the fraction of the total number of reads that are duplicates of another. This can derive from over-amplifcation of the library, or lots of single adapters. This can be later checked with the Deduplication check. A good library and sequencing run should have very low amounts of duplicates reads.
 
 <p align="center">
-	<img src="images/output/fastqc/sequence_counts.png" width="75%" height = "75%">
+  <img src="images/output/fastqc/sequence_counts.png" width="75%" height = "75%">
 </p>
 
 #### Sequence Quality Histograms
@@ -121,7 +121,6 @@ You will often see that the first 5 or so bases have slightly lower quality than
 <p align="center">
   <img src="images/output/fastqc/sequencing_quality_histogram.png" width="75%" height = "75%">
 </p>
-
 
 Things to watch out for:
 


### PR DESCRIPTION
Tweaking markdown linting to allow doc image justification

Allows `p` (for center justifying) and `img` (for resizing) tags

## PR checklist
 - [x] This comment contains a description of changes (with reason)

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
