### PR TITLE
Pr template fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,17 @@
+Many thanks to contributing to nf-core/eager!
+
+Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).
+
+## PR checklist
+
+ - [ ] This comment contains a description of changes (with reason)
+ - [ ] If you've fixed a bug or added code that should be tested, add tests!
+ - [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
+ - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
+ - [ ] Make sure your code lints (`nf-core lint .`).
+ - [ ] Usage Documentation in `docs/usage.md` is updated
+ - [ ] Output Documentation in `docs/output.md` is updated
+ - [ ] `CHANGELOG.md` is updated
+ - [ ] `README.md` is updated
+
+**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md


### PR DESCRIPTION
I just realised hte updated PR info template was not displaying. It wasn't in the right place - should be fixed now according to https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository

## PR checklist
 - [x] This comment contains a description of changes (with reason)

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
