### PR TITLE
Revert "Bump mtnuc to 0.6"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * angsd=0.923->0.931
 * gatk4=4.1.2.0->4.1.4.1
 * conda-forge::r-rmarkdown=1.12->1.18
-* mtnucratio=0.5->0.6
 * pysam=0.15.2->0.15.3
 * python=3.6.3->3.7.1
 

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - bioconda::preseq=2.0.3
   - bioconda::fastp=0.20.0
   - bioconda::bamutil=1.0.14
-  - bioconda::mtnucratio=0.6
+  - bioconda::mtnucratio=0.5
   - pysam=0.15.3
   - python=3.7.1
   - bioconda::freebayes=1.3.1


### PR DESCRIPTION
Reverts nf-core/eager#307 as the new conda build for MtNucRatio doesn't work!

```
 fellows@datpx11799:~$ mtnucratio 
Error: Unable to access jarfile /home/fellows/miniconda3/share/mtnucratio-0.6-0/MTNucRatioCalculator-0.5.jar
```