### PR TITLE
Resource requirement and abstraction process fixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [#302](https://github.com/nf-core/eager/issues/302) - Added mitochondrial to nuclear ratio calculation
 * [#302](https://github.com/nf-core/eager/issues/302) - Added VCF2Genome for concensus sequence generation
 * Fancy new logo from [ZandraFagernas](https://github.com/ZandraFagernas)
-* [#286](https://github.com/nf-core/eager/issues/286) Adds pipeline-specific profiles (loaded from nf-core configs)
+* [#286](https://github.com/nf-core/eager/issues/286) - Adds pipeline-specific profiles (loaded from nf-core configs)
+* [#310](https://github.com/nf-core/eager/issues/310) - Generalises base.config
 
 ### `Fixed`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -69,7 +69,6 @@ process {
   }
 
   withName:qualimap{
-    cpus = { check_max(8 * task.attempt, 'cpus') }
     errorStrategy = 'ignore'
   }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -11,78 +11,76 @@
 
 process {
   cpus = { check_max( 1 * task.attempt, 'cpus' ) }
-  memory = { check_max( 8.GB * task.attempt, 'memory' ) }
+  memory = { check_max( 4.GB * task.attempt, 'memory' ) }
   time = { check_max( 2.h * task.attempt, 'time' ) }
 
   errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
-  maxRetries = 1
+  maxRetries = 3
   maxErrors = '-1'
+
+  // Generic resource requirements - s(ingle)c(ore)/m(ulti)c(ore)
+
+  withLabel:'sc_tiny'{
+      cpus = { check_max( 1, 'cpus' ) }
+      memory = { check_max( 1.GB * task.attempt, 'memory' ) }
+      time = { check_max( 2.h * task.attempt, 'time' ) }
+  }
+
+  withLabel:'sc_small'{
+      cpus = { check_max( 1, 'cpus' ) }
+      memory = { check_max( 4.GB * task.attempt, 'memory' ) }
+      time = { check_max( 2.h * task.attempt, 'time' ) }
+  }
+
+  withLabel:'sc_medium'{
+      cpus = { check_max( 1, 'cpus' ) }
+      memory = { check_max( 8.GB * task.attempt, 'memory' ) }
+      time = { check_max( 2.h * task.attempt, 'time' ) }
+  }
+
+  withLabel:'mc_small'{
+      cpus = { check_max( 2, 'cpus' ) }
+      memory = { check_max( 4.GB * task.attempt, 'memory' ) }
+      time = { check_max( 2.h * task.attempt, 'time' ) }
+  }
+
+  withLabel:'mc_medium' {
+      cpus = { check_max( 4, 'cpus' ) }
+      memory = { check_max( 8.GB * task.attempt, 'memory' ) }
+      time = { check_max( 2.h * task.attempt, 'time' ) }
+  }
+
+  withLabel:'mc_large'{
+      cpus = { check_max( 8, 'cpus' ) }
+      memory = { check_max( 16.GB * task.attempt, 'memory' ) }
+      time = { check_max( 2.h * task.attempt, 'time' ) }
+  }
+
+  withLabel:'mc_huge'{
+      cpus = { check_max( 32, 'cpus' ) }
+      memory = { check_max( 256.GB * task.attempt, 'memory' ) }
+      time = { check_max( 2.h * task.attempt, 'time' ) }
+  }
 
   // Process-specific resource requirements (others leave at default, e.g. Fastqc)
   withName:get_software_versions {
     memory = { check_max( 2.GB, 'memory' ) }
     cache = false
   }
-  withName:convertBam {
-    cpus = { check_max(8 * task.attempt, 'cpus') }
-  }
-  withName:makeSeqDict {
-    memory = { check_max( 16.GB * task.attempt, 'memory' ) }
-  }
-  withname:makeBWAIndex {
-    time = params.large_ref ? '12.h' : { check_max(8.h * task.attempt, 'time') }
-  }
-  withName:bwa {
-    memory = { check_max( 16.GB * task.attempt, 'memory' ) }
-    cpus = { check_max(8 * task.attempt, 'cpus') }
-    time = { check_max(8.h * task.attempt, 'time') }
-  }
-  withName:bwamem{
-    memory = { check_max( 16.GB * task.attempt, 'memory' ) }
-    cpus = { check_max(8 * task.attempt, 'cpus') }
-    time = { check_max(8.h * task.attempt, 'time') }
-  }
+
   withName:qualimap{
     cpus = { check_max(8 * task.attempt, 'cpus') }
     errorStrategy = 'ignore'
   }
-  withName:bam_trim{
-    cpus = { check_max(4 * task.attempt, 'cpus') }
-  }
-  withName:markDup{
-    cpus = { check_max(8 * task.attempt, 'cpus') }
-  }
+
   withName:preseq {
     errorStrategy = 'ignore'
   }
-  withName: fastqc {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
-  }
+
   withName: multiqc {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
-  withName: damageprofiler {
-    time = params.large_ref ? { check_max(8.h * task.attempt, 'time') } : { check_max(2.h * task.attempt, 'time')}
-  }
-  withName: strip_input_fastq {
-    cpus = { check_max(8 * task.attempt, 'cpus') }
-    memory = { check_max( 8.GB * task.attempt, 'memory' ) }
-  }
-  withName: malt {
-    memory = { check_max( 128.GB * task.attempt, 'memory' ) }
-    cpus = { check_max(16 * task.attempt, 'cpus') }
-    time = { check_max(2.h * task.attempt, 'time') }
-  }
-  withName: maltextract {
-    memory = { check_max( 8.GB * task.attempt, 'memory' ) }
-    cpus = { check_max(4 * task.attempt, 'cpus') }
-  }
-  withName: vcf2genome {
-    memory = { check_max( 4.GB * task.attempt, 'memory' ) }
-    cpus =  1
-  }
 }
-
 
 params {
   // Defaults only, expecting to be overwritten

--- a/conf/base.config
+++ b/conf/base.config
@@ -68,7 +68,7 @@ process {
     cache = false
   }
 
-  withName:strip_fastq {
+  withName:strip_input_fastq {
      time = { check_max( 4.h * task.attempt, 'time' ) }
   }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -68,6 +68,10 @@ process {
     cache = false
   }
 
+  withName:strip_fastq {
+     time = { check_max( 4.h * task.attempt, 'time' ) }
+  }
+
   withName:qualimap{
     errorStrategy = 'ignore'
   }

--- a/conf/base.config
+++ b/conf/base.config
@@ -77,6 +77,11 @@ process {
     errorStrategy = 'ignore'
   }
 
+  // Add 141 ignore due to unclean pipe closing by pmdtools https://github.com/pontussk/PMDtools/issues/7
+  withName: pmdtools {
+    errorStrategy = { task.exitStatus in [141] ? 'ignore' : 'retry' }
+  }
+
   withName: multiqc {
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,7 +114,7 @@ Use this parameter to choose a configuration profile. Profiles can give configur
 For more details on how to set up your own private profile, please see [installation](../configuration/adding_your_own.md).
 
 **Basic profiles**
-These are basic profiles which primarily define where you derive the pipeline's software packages from. These are typically the profiles you would use if you are running the pipeline on your **own PC*- (vs. a HPC cluster - see below).
+These are basic profiles which primarily define where you derive the pipeline's software packages from. These are typically the profiles you would use if you are running the pipeline on your **own PC** (vs. a HPC cluster - see below).
 
 - `awsbatch`
   - A generic configuration profile to be used with AWS Batch.
@@ -274,7 +274,7 @@ The output directory where the results will be saved.
 
 #### `-w / -work-dir`
 
-The output directory where _intermediate_ files will be saved. It is **highly recommended*- that this is the same path as `--outdir`, otherwise you may 'lose' your intermediate files if you need to re-run a pipeline. By default, if this flag is not given, the intermediate files will be saved in a `work/` and `.nextflow/` directory from wherever you have run EAGER from.
+The output directory where _intermediate_ files will be saved. It is **highly recommended** that this is the same path as `--outdir`, otherwise you may 'lose' your intermediate files if you need to re-run a pipeline. By default, if this flag is not given, the intermediate files will be saved in a `work/` and `.nextflow/` directory from wherever you have run EAGER from.
 
 ### Optional Reference Options
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -155,6 +155,8 @@ We currently offer a EAGER specific profile for
   - A profiler for the S/CDAG cluster at the Department of Archaeogenetics of the Max Planck Institute for the Science of Human History
   - In addition to the nf-core wide profile, this also sets the MALT resources to match our commonly used databases
 
+Further institutions can be added at [nf-core/configs](https://github.com/nf-core/configs). Please ask the eager developers to add your institution to the list above, if you add one!
+
 #### `--reads`
 
 Use this to specify the location of your input FastQ (optionally gzipped) or BAM file(s). The files maybe either from a single, or multiple samples. For example:

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - bioconda::picard=2.21.4
   - bioconda::samtools=1.9
   - bioconda::dedup=0.12.5
-  - bioconda::angsd=0.931
+  - bioconda::angsd=0.921
   - bioconda::circularmapper=1.93.4
   - bioconda::gatk4=4.1.4.1
   - bioconda::qualimap=2.2.2d

--- a/main.nf
+++ b/main.nf
@@ -1720,11 +1720,11 @@ ch_gatk_download = Channel.value("download")
   params.run_genotyping && params.genotyping_tool == 'ug'
 
   input:
-  file fasta from fasta_for_indexing
-  file jar from ch_unifiedgenotyper_jar
+  val fasta from fasta_for_indexing
+  val jar from ch_unifiedgenotyper_jar
   file bam from ch_damagemanipulation_for_genotyping_ug
-  file fai from ch_fai_for_ug
-  file dict from ch_dict_for_ug
+  val fai from ch_fai_for_ug
+  val dict from ch_dict_for_ug
 
   output: 
   file "*vcf.gz" into ch_ug_for_multivcfanalyzer,ch_ug_for_vcf2genome
@@ -1759,11 +1759,11 @@ ch_gatk_download = Channel.value("download")
   params.run_genotyping && params.genotyping_tool == 'hc'
 
   input:
-  file fasta from fasta_for_indexing
+  val fasta from fasta_for_indexing
   file bam from ch_damagemanipulation_for_genotyping_hc
-  file fai from ch_fai_for_hc
-  file dict from ch_dict_for_hc
-  file bai from ch_damagemanipulationindex_for_genotyping_hc
+  val fai from ch_fai_for_hc
+  val dict from ch_dict_for_hc
+  val bai from ch_damagemanipulationindex_for_genotyping_hc
 
   output: 
   file "*vcf.gz" into ch_vcf_hc
@@ -1795,11 +1795,11 @@ ch_gatk_download = Channel.value("download")
   params.run_genotyping && params.genotyping_tool == 'freebayes'
 
   input:
-  file fasta from fasta_for_indexing
+  val fasta from fasta_for_indexing
   file bam from ch_damagemanipulation_for_genotyping_freebayes
-  file fai from ch_fai_for_freebayes
-  file dict from ch_dict_for_freebayes
-  file bai from ch_damagemanipulationindex_for_genotyping_freebayes
+  val fai from ch_fai_for_freebayes
+  val dict from ch_dict_for_freebayes
+  val bai from ch_damagemanipulationindex_for_genotyping_freebayes
 
   output: 
   file "*vcf.gz" into ch_vcf_freebayes
@@ -1829,7 +1829,7 @@ process vcf2genome {
 
   input:
   file vcf from ch_ug_for_vcf2genome
-  file fasta from fasta_for_indexing
+  val fasta from fasta_for_indexing
 
   output:
   file "*.fasta.gz"

--- a/main.nf
+++ b/main.nf
@@ -1242,19 +1242,22 @@ process samtools_filter {
         """
     } else if("${params.bam_discard_unmapped}" && "${params.bam_unmapped_type}" == "bam"){
         """
-        samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
+        samtools view -h $bam | samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam
+        samtools view -h $bam | samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam
         samtools index "${size}" ${prefix}.filtered.bam
         """
     } else if("${params.bam_discard_unmapped}" && "${params.bam_unmapped_type}" == "fastq"){
         """
-        samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
+        samtools view -h $bam | samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam
+        samtools view -h $bam | samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam
         samtools index "${size}" ${prefix}.filtered.bam
         samtools fastq -tn ${prefix}.unmapped.bam | pigz -p ${task.cpus} > ${prefix}.unmapped.fastq.gz
         rm ${prefix}.unmapped.bam
         """
     } else if("${params.bam_discard_unmapped}" && "${params.bam_unmapped_type}" == "both"){
         """
-        samtools view -h $bam | tee >(samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam) >(samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
+        samtools view -h $bam | samtools view - -@ ${task.cpus} -f4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.unmapped.bam)
+        samtools view -h $bam | samtools view - -@ ${task.cpus} -F4 -q ${params.bam_mapping_quality_threshold} -o ${prefix}.filtered.bam)
         samtools index "${size}" ${prefix}.filtered.bam
         samtools fastq -tn ${prefix}.unmapped.bam | pigz -p ${task.cpus} > ${prefix}.unmapped.fastq.gz
         """

--- a/main.nf
+++ b/main.nf
@@ -1711,7 +1711,7 @@ ch_gatk_download = Channel.value("download")
 */
 
  process genotyping_ug {
-  'mc_small'
+  'mc_medium'
   tag "${prefix}"
   publishDir "${params.outdir}/genotyping", mode: 'copy'
 
@@ -1751,7 +1751,7 @@ ch_gatk_download = Channel.value("download")
  }
 
   process genotyping_hc {
-  label  'mc_small'
+  label  'mc_medium'
   tag "${prefix}"
   publishDir "${params.outdir}/genotyping", mode: 'copy'
 
@@ -1787,6 +1787,7 @@ ch_gatk_download = Channel.value("download")
  *  Step 12c: FreeBayes genotyping, should probably add in some options for users to set 
  */ 
  process genotyping_freebayes {
+  label 'mc_medium'
   tag "${prefix}"
   publishDir "${params.outdir}/genotyping", mode: 'copy'
 

--- a/main.nf
+++ b/main.nf
@@ -1720,11 +1720,11 @@ ch_gatk_download = Channel.value("download")
   params.run_genotyping && params.genotyping_tool == 'ug'
 
   input:
-  val fasta from fasta_for_indexing
-  val jar from ch_unifiedgenotyper_jar
+  val fasta from fasta_for_indexing.collect()
+  val jar from ch_unifiedgenotyper_jar.collect()
   file bam from ch_damagemanipulation_for_genotyping_ug
-  val fai from ch_fai_for_ug
-  val dict from ch_dict_for_ug
+  val fai from ch_fai_for_ug.collect()
+  val dict from ch_dict_for_ug.collect()
 
   output: 
   file "*vcf.gz" into ch_ug_for_multivcfanalyzer,ch_ug_for_vcf2genome


### PR DESCRIPTION
This includes a range of bug fixes and enhancements

1. Generalises default resource requirements rather than process specific settings with `withLabel` to address https://github.com/nf-core/eager/issues/310
2.  Fixes a bug reported by Marcel Keller that genotyping was only running for one sample. This was due to the reference FASTA being consumed. I also expanded to ensure all processes have independent FASTA input channels. (thanks to @drpatelh @mahesh-panchal for troubleshooting)
3. Adds an ignore for pipe errors (exit code 141) for pmdtools as pmdtools still fails even if samtools says 'err no'
4. Adds documentation for pipeline specific institutional profiles.
5. Fixes an instability with using `tee` for samtools which was trying to paralellise within a paralellised process

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
