### PR TITLE
Bugfix MALT error retries

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -67,7 +67,6 @@ process {
     memory = { check_max( 2.GB, 'memory' ) }
     cache = false
   }
-  
 
   withName:qualimap{
     errorStrategy = 'ignore'
@@ -80,6 +79,11 @@ process {
   // Add 141 ignore due to unclean pipe closing by pmdtools https://github.com/pontussk/PMDtools/issues/7
   withName: pmdtools {
     errorStrategy = { task.exitStatus in [141] ? 'ignore' : 'retry' }
+  }
+
+  // Add 1 retry as not enough heapspace java error gives exit code 1
+  withName: malt {
+    errorStrategy = { task.exitStatus in [1] ? 'retry' : 'finish' } 
   }
 
   withName: multiqc {


### PR DESCRIPTION
This PR fixes a small 'bug' due to Java reporting an exit code as 1, if the heapspace runs out of memory.

Adding exit code 1 to a 'retry' rather than finish, at least gives the recently added MALT a chance to get enough memory before running out due to retry-limit. 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] Make sure your code lints (`nf-core lint .`).

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
