### PR TITLE
Added minimum nxf ver to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Additional functionality contained by the pipeline currently includes:
 
 ## Quick Start
 
-1. Install [`nextflow`](https://nf-co.re/usage/installation)
+1. Install [`nextflow`](https://nf-co.re/usage/installation) (>= v19.10.0)
 
 2. Install one of [`docker`](https://docs.docker.com/engine/installation/), [`singularity`](https://www.sylabs.io/guides/3.0/user-guide/) or [`conda`](https://conda.io/miniconda.html)
 


### PR DESCRIPTION
Minor documentation change. Unfortunately nextflow doesn't actually stop if the user's version is not the one listed in the manifest.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
