### PR TITLE
Join bam and fastq channel for strip_input_fastq process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Fixed`
 
 * [#368](https://github.com/nf-core/eager/issues/368) - Fixed the profile `test` to contain a parameter for `--paired_end`.
+* [#376](https://github.com/nf-core/eager/pull/376) - Join bam and fastq channel for strip_input_fastq process
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -1284,6 +1284,10 @@ if (params.run_bam_filtering) {
 }
 
 
+ch_filtering_for_stripfastq
+  .map {it -> [it.baseName.tokenize('.')[0], it]}
+  .set {ch_indexed_filtering_for_stripfastq}
+
 
 
 process strip_input_fastq {
@@ -1295,8 +1299,7 @@ process strip_input_fastq {
     params.strip_input_fastq
 
     input: 
-    set val(name), file(fq) from ch_convertbam_for_stripfastq
-    file bam from ch_filtering_for_stripfastq
+    set val(name), file(fq), file(bam) from ch_convertbam_for_stripfastq.join(ch_indexed_filtering_for_stripfastq)
 
     output:
     file "*.fq.gz" into ch_output_from_stripfastq


### PR DESCRIPTION
To make sure that fastq and bam files are coming from the same samples.
Limitation: sample name containing the `.` character
Definitive fix would be a total refactoring of channels, coming with TSV input by @jfy133 

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [X] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] `CHANGELOG.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
