### PR TITLE
Bump up FASTQC base resources

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -820,7 +820,7 @@ if (params.run_convertbam) {
  * STEP 1a - FastQC
  */
 process fastqc {
-    label 'sc_tiny'
+    label 'sc_small'
     tag "$name"
     publishDir "${params.outdir}/FastQC/input_fastq", mode: 'copy',
         saveAs: {filename -> filename.indexOf(".zip") > 0 ? "zips/$filename" : "$filename"}
@@ -980,7 +980,7 @@ if (!params.skip_adapterremoval) {
 * STEP 2b - FastQC after clipping/merging (if applied!)
 */
 process fastqc_after_clipping {
-    label 'sc_tiny'
+    label 'sc_small'
     tag "${name}"
     publishDir "${params.outdir}/FastQC/after_clipping", mode: 'copy',
         saveAs: {filename -> filename.indexOf(".zip") > 0 ? "zips/$filename" : "$filename"}


### PR DESCRIPTION
Really small FASTQC label bump to 4GB memory to close https://github.com/nf-core/eager/issues/378