### PR TITLE
Patch fastqc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [#368](https://github.com/nf-core/eager/issues/368) - Fixed the profile `test` to contain a parameter for `--paired_end`.
 * Mini bugfix for typo in line 1260+1261
 * Added basic json_schema
+* [#379](https://github.com/nf-core/eager/issues/378) - Fixed insufficient memory requirements for FASTQC edge case
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -836,7 +836,7 @@ process fastqc {
 
     script:
     """
-    fastqc -t $cpus -q $reads
+    fastqc -t ${task.cpus} -q $reads
     rename 's/_fastqc\\.zip\$/_raw_fastqc.zip/' *_fastqc.zip
     rename 's/_fastqc\\.html\$/_raw_fastqc.html/' *_fastqc.html
     """
@@ -995,7 +995,7 @@ process fastqc_after_clipping {
 
     script:
     """
-    fastqc -t $cpus -q $reads
+    fastqc -t ${task.cpus} -q $reads
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -820,7 +820,7 @@ if (params.run_convertbam) {
  * STEP 1a - FastQC
  */
 process fastqc {
-    label 'sc_small'
+    label 'mc_small'
     tag "$name"
     publishDir "${params.outdir}/FastQC/input_fastq", mode: 'copy',
         saveAs: {filename -> filename.indexOf(".zip") > 0 ? "zips/$filename" : "$filename"}
@@ -836,7 +836,7 @@ process fastqc {
 
     script:
     """
-    fastqc -q $reads
+    fastqc -t $cpus -q $reads
     rename 's/_fastqc\\.zip\$/_raw_fastqc.zip/' *_fastqc.zip
     rename 's/_fastqc\\.html\$/_raw_fastqc.html/' *_fastqc.html
     """
@@ -980,7 +980,7 @@ if (!params.skip_adapterremoval) {
 * STEP 2b - FastQC after clipping/merging (if applied!)
 */
 process fastqc_after_clipping {
-    label 'sc_small'
+    label 'mc_small'
     tag "${name}"
     publishDir "${params.outdir}/FastQC/after_clipping", mode: 'copy',
         saveAs: {filename -> filename.indexOf(".zip") > 0 ? "zips/$filename" : "$filename"}
@@ -995,7 +995,7 @@ process fastqc_after_clipping {
 
     script:
     """
-    fastqc -q $reads
+    fastqc -t $cpus -q $reads
     """
 }
 


### PR DESCRIPTION
# nf-core/eager pull request

This fixes #378 by making FASTQC multi-core (because FASTQC assigns 250MB memory to each thread)

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [x] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
