### PR TITLE
Add caveat dependencies when running with --email

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -509,7 +509,6 @@ Set this parameter to your e-mail address to get a summary e-mail with details o
 
 Note that this functionality requires either `mail` or `sendmail` to be installed on your system.
 
-
 #### `--plaintext_email`
 
 Set to receive plain-text e-mails instead of HTML formatted.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -507,6 +507,13 @@ Do not set this higher than what is available on your workstation or computing n
 
 Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.
 
+Note that this functionality requires either `mail` or `sendmail` to be installed on your system.
+
+
+#### `--plaintext_email`
+
+Set to receive plain-text e-mails instead of HTML formatted.
+
 #### `-name`
 
 Name for the pipeline run. If not specified, Nextflow will automatically generate a random mnemonic.
@@ -547,10 +554,6 @@ Provide git commit id for custom Institutional configs hosted at `nf-core/config
 \#\# Download and use config file with following git commid id
 --custom_config_version d52db660777c4bf36546ddb188ec530c3ada1b96
 ```
-
-#### `--plaintext_email`
-
-Set to receive plain-text e-mails instead of HTML formatted.
 
 ## Adjustable parameters for nf-core/eager
 


### PR DESCRIPTION
# nf-core/eager pull request

Just found a case where I didn't have `mail` or `sendmail` installed on my laptop, and `--email` was hitting funny errors. Clarified in docs.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
