### PR TITLE
Throw error and exit if --fasta_index does not end in '.fai'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [dev]
 
 ### `Added`
+* Added sanity check and clearer error message when `--fasta_index` is provided and filepath does not end in `.fai`.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [dev]
 
 ### `Added`
+
 * Added sanity check and clearer error message when `--fasta_index` is provided and filepath does not end in `.fai`.
 
 ### `Fixed`

--- a/main.nf
+++ b/main.nf
@@ -261,6 +261,11 @@ if ( params.fasta.isEmpty () ){
     bwa_base = params.fasta.substring(lastPath+1)
 }
 
+// Check that fasta index file path ends in '.fai'
+if (params.fasta_index && !params.fasta_index.endsWith(".fai")) {
+    exit 1, "The specified fasta index file (${params.fasta_index}) is not valid. Fasta index files should end in '.fai'."
+}
+
 // Check if genome exists in the config file. params.genomes is from igenomes.conf, params.genome specified by user
 if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {
     exit 1, "The provided genome '${params.genome}' is not available in the iGenomes file. Currently the available genomes are ${params.genomes.keySet().join(", ")}"


### PR DESCRIPTION
Added a small sanity check that throws an error when `--fasta_index` is provided and does not end with `.fai` as is expected. The error message thrown should make it easier for users to understand the problem and troubleshoot it.

# nf-core/eager pull request

Many thanks for contributing to nf-core/eager!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [ ] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
