### PR TITLE
Fix for warning reported in #439

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -651,7 +651,7 @@ Channel.from(summary.collect{ [it.key, it.value] })
 if(!params.bwa_index && !params.fasta.isEmpty() && (params.mapper == 'bwaaln' || params.mapper == 'bwamem' || params.mapper == 'circularmapper')){
 process makeBWAIndex {
     label 'sc_medium'
-    tag {fasta}
+    tag "${fasta}"
     publishDir path: "${params.outdir}/reference_genome/bwa_index", mode: 'copy', saveAs: { filename -> 
             if (params.save_reference) filename 
             else if(!params.save_reference && filename == "where_are_my_files.txt") filename
@@ -687,7 +687,7 @@ if (params.fasta_index != '') {
 
 process makeFastaIndex {
     label 'sc_small'
-    tag {fasta}
+    tag "${fasta}"
     publishDir path: "${params.outdir}/reference_genome/fasta_index", mode: 'copy', saveAs: { filename -> 
             if (params.save_reference) filename 
             else if(!params.save_reference && filename == "where_are_my_files.txt") filename
@@ -727,7 +727,7 @@ if (params.seq_dict != '') {
 
 process makeSeqDict {
     label 'sc_medium'
-    tag {fasta}
+    tag "${fasta}"
     publishDir path: "${params.outdir}/reference_genome/seq_dict", mode: 'copy', saveAs: { filename -> 
             if (params.save_reference) filename 
             else if(!params.save_reference && filename == "where_are_my_files.txt") filename


### PR DESCRIPTION
# nf-core/eager pull request

Replaces the 'path' tag with an actual string, to close #439 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
