### PR TITLE
Update main.nf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
+      - name: HELPTEXT Run with the help flag
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} --help
       - name: Get test data for cases where we don't use TSV input
         run: |
           git clone --single-branch --branch eager https://github.com/nf-core/test-datasets.git data

--- a/main.nf
+++ b/main.nf
@@ -109,7 +109,7 @@ def helpMessage() {
       --damageprofiler_threshold    Specify number of bases to consider for damageProfiler (e.g. on damage plot). Default: ${params.damageprofiler_threshold}
       --damageprofiler_yaxis        Specify the maximum misincorporation frequency that should be displayed on damage plot. Set to 0 to 'autoscale'. Default: ${params.damageprofiler_yaxis} 
       --run_pmdtools                Turn on PMDtools
-      --udg_type                    Specify here if you have UDG treated libraries, Set to 'half' for partial treatment, or 'full' for UDG. If not set, libraries are assumed to have no UDG treatment ('none'). Default: ${udg_type}
+      --udg_type                    Specify here if you have UDG treated libraries, Set to 'half' for partial treatment, or 'full' for UDG. If not set, libraries are assumed to have no UDG treatment ('none'). Default: ${params.udg_type}
       --pmdtools_range              Specify range of bases for PMDTools. Default: ${params.pmdtools_range} 
       --pmdtools_threshold          Specify PMDScore threshold for PMDTools. Default: ${params.pmdtools_threshold} 
       --pmdtools_reference_mask     Specify a path to reference mask for PMDTools.


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)

While trying to run with `--help` I got the following error:
```
nextflow run nf-core/eager -r dev --help
N E X T F L O W  ~  version 20.04.1
Launching `nf-core/eager` [astonishing_darwin] - revision: 58e0d916cb [dev]
----------------------------------------------------
                                        ,--./,-.
        ___     __   __   __   ___     /,-._.--~'
  |\ | |__  __ /  ` /  \ |__) |__         }  {
  | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                        `._,._,'
  nf-core/eager v2.2.0dev
----------------------------------------------------
No such variable: udg_type

 -- Check script '/home/tcl/.nextflow/assets/nf-core/eager/main.nf' at line: 16 or see '.nextflow.log' file for more details
```

A quick look revealed that `udg_type` is called `params.udg_type` in the code, so I assume this caused the error. 

Maybe `--help` should become an automated test for the pipeline as well? 