### PR TITLE
Add proper fulltests with org level secrets

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -1,16 +1,15 @@
 name: nf-core AWS test
 # This workflow is triggered on push to the master branch and on published releases.
-# It runs the -profile 'test_tsv' on AWS batch
+# It runs the -profile 'test_full' on AWS batch
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   run-awstest:
     if: github.repository == 'nf-core/eager'
-    name: Run AWS test
+    name: Run AWS full tests
     runs-on: ubuntu-latest
     steps:
       - name: Setup Miniconda
@@ -21,6 +20,9 @@ jobs:
       - name: Install awscli
         run: conda install -c conda-forge awscli
       - name: Start AWS batch job
+        # Add full size test data (but still relatively small datasets for few samples) 
+        # on the `test_full.config` test runs with only one set of parameters
+        # Then specify `-profile test_full` instead of `-profile test` on the AWS batch command
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWSTEST_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWSTEST_KEY_SECRET}}
@@ -34,4 +36,4 @@ jobs:
           --job-name nf-core-eager \
           --job-queue $AWS_JOB_QUEUE \
           --job-definition $AWS_JOB_DEFINITION \
-          --container-overrides '{"command": ["nf-core/eager", "-r '"${GITHUB_SHA}"' -profile test_tsv --outdir s3://'"${AWS_S3_BUCKET}"'/eager/results-'"${GITHUB_SHA}"' -w s3://'"${AWS_S3_BUCKET}"'/eager/work-'"${GITHUB_SHA}"' -with-tower"], "environment": [{"name": "TOWER_ACCESS_TOKEN", "value": "'"$TOWER_ACCESS_TOKEN"'"}]}'
+          --container-overrides '{"command": ["nf-core/eager", "-r '"${GITHUB_SHA}"' -profile test_full --outdir s3://nf-core-awsmegatests/eager/results-'"${GITHUB_SHA}"' -w s3://nf-core-awsmegatests/eager/work-'"${GITHUB_SHA}"' -with-tower"], "environment": [{"name": "TOWER_ACCESS_TOKEN", "value": "'"$TOWER_ACCESS_TOKEN"'"}]}'

--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -1,4 +1,4 @@
-name: nf-core AWS test
+name: nf-core AWS full test
 # This workflow is triggered on push to the master branch and on published releases.
 # It runs the -profile 'test_full' on AWS batch
 
@@ -24,9 +24,9 @@ jobs:
         # on the `test_full.config` test runs with only one set of parameters
         # Then specify `-profile test_full` instead of `-profile test` on the AWS batch command
         env:
-          AWS_ACCESS_KEY_ID: ${{secrets.AWSTEST_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWSTEST_KEY_SECRET}}
-          TOWER_ACCESS_TOKEN: ${{secrets.AWSTEST_TOWER_TOKEN}}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          TOWER_ACCESS_TOKEN: ${{secrets.AWS_TOWER_TOKEN}}
           AWS_JOB_DEFINITION: ${{secrets.AWS_JOB_DEFINITION}}
           AWS_JOB_QUEUE: ${{secrets.AWS_JOB_QUEUE}}
           AWS_S3_BUCKET: ${{secrets.AWS_S3_BUCKET}}
@@ -36,4 +36,4 @@ jobs:
           --job-name nf-core-eager \
           --job-queue $AWS_JOB_QUEUE \
           --job-definition $AWS_JOB_DEFINITION \
-          --container-overrides '{"command": ["nf-core/eager", "-r '"${GITHUB_SHA}"' -profile test_full --outdir s3://nf-core-awsmegatests/eager/results-'"${GITHUB_SHA}"' -w s3://nf-core-awsmegatests/eager/work-'"${GITHUB_SHA}"' -with-tower"], "environment": [{"name": "TOWER_ACCESS_TOKEN", "value": "'"$TOWER_ACCESS_TOKEN"'"}]}'
+          --container-overrides '{"command": ["nf-core/eager", "-r '"${GITHUB_SHA}"' -profile test_full --outdir s3://'"${AWS_S3_BUCKET}"'/eager/results-'"${GITHUB_SHA}"' -w s3://'"${AWS_S3_BUCKET}"'/eager/work-'"${GITHUB_SHA}"' -with-tower"], "environment": [{"name": "TOWER_ACCESS_TOKEN", "value": "'"$TOWER_ACCESS_TOKEN"'"}]}'

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -22,9 +22,9 @@ jobs:
         run: conda install -c conda-forge awscli
       - name: Start AWS batch job
         env:
-          AWS_ACCESS_KEY_ID: ${{secrets.AWSTEST_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWSTEST_KEY_SECRET}}
-          TOWER_ACCESS_TOKEN: ${{secrets.AWSTEST_TOWER_TOKEN}}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          TOWER_ACCESS_TOKEN: ${{secrets.AWS_TOWER_TOKEN}}
           AWS_JOB_DEFINITION: ${{secrets.AWS_JOB_DEFINITION}}
           AWS_JOB_QUEUE: ${{secrets.AWS_JOB_QUEUE}}
           AWS_S3_BUCKET: ${{secrets.AWS_S3_BUCKET}}


### PR DESCRIPTION
This adds proper AWS Full tests and AWS Tests for eager. Maybe @ggabernet can have a look as she opened the ones at Sarek/ATACseq/.... ;-)

Full test profile will be available once we merge in #418 , until then this just runs `test_tsv` as profile. 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [x] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [ ] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [ ] `README.md` is updated
