### PR TITLE
Bwa index patch

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -290,7 +290,7 @@ if (params.mapper != 'bwaaln' && !params.mapper == 'circularmapper' && !params.m
 }
 
 // Index files provided? Then check whether they are correct and complete
-if( params.bwa_index && (params.mapper == 'bwaaln' | params.mapper == 'bwamem')){
+if( params.bwa_index != '' && (params.mapper == 'bwaaln' | params.mapper == 'bwamem')){
     lastPath = params.bwa_index.lastIndexOf(File.separator)
     bwa_dir =  params.bwa_index.substring(0,lastPath+1)
     bwa_base = params.bwa_index.substring(lastPath+1)
@@ -697,7 +697,7 @@ Channel.from(summary.collect{ [it.key, it.value] })
 ///////////////////////////////////////////////////
 
 // BWA Index
-if(!params.bwa_index && !params.fasta.isEmpty() && (params.mapper == 'bwaaln' || params.mapper == 'bwamem' || params.mapper == 'circularmapper')){
+if(params.bwa_index == '' && !params.fasta.isEmpty() && (params.mapper == 'bwaaln' || params.mapper == 'bwamem' || params.mapper == 'circularmapper')){
 process makeBWAIndex {
     label 'sc_medium'
     tag "${fasta}"


### PR DESCRIPTION
# nf-core/eager pull request

This fixes BWA index default values so arent a boolean but a string (as would be given by a user). This is to fix a AWS bug reported internally by @apeltzer  

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
