### PR TITLE
Added nuclear_contamination to MultiQC report as custom content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added large 'fullsize' dataset test-profiles for ancient fish, human, and a draft pathogen contexts.
 * [#257](https://github.com/nf-core/eager/issues/257) Added the bowtie2 aligner as option for mapping, following Poullet and Orlando 2020 doi: [10.3389/fevo.2020.00105](https://doi.org/10.3389/fevo.2020.00105)
 * [#451] Adds ANGSD genotype likelihood calculations as alternative to typical 'genotypers'
+* [#504] Removed sexdeterrmine-snps plot from MultiQC report.
+* Nuclear contamination results are now shown in the MultiQC report.
 
 ### `Fixed`
 
@@ -55,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Latest version of FreeBayes (1.3.2)
 * Latest version of xopen (0.9.0)
 * Added Bowtie 2 (2.4.1)
+* Latest version of Sex.DetERRmine (1.1.2)
 
 ## [2.1.0] - 2020-03-05 - "Ravensburg"
 

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -196,6 +196,15 @@ table_columns_placement:
     custom_content:
         endogenous_dna: 600
         endogenous_dna_post: 610
+        Num_SNPs: 1100
+        Method1_MOM_estimate: 1110
+        Method1_MOM_SE: 1120
+        Method1_ML_estimate: 1130
+        Method1_ML_SE: 1140
+        Method2_MOM_estimate: 1150
+        Method2_MOM_SE: 1160
+        Method2_ML_estimate: 1170
+        Method2_ML_SE: 1180
     DeDup:
         mapped_after_dedup: 620
         clusterfactor: 630
@@ -222,7 +231,7 @@ table_columns_placement:
         5_x_pc: 860
         avg_gc: 870
     sexdeterrmine:
-        RateX: 100
+        RateX: 1000
         RateY: 1010
     MultiVCFAnalyzer:
         Heterozygous SNP alleles (percent): 1100

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -164,17 +164,18 @@ table_columns_visible:
     MultiVCFAnalyzer:
         Heterozygous SNP alleles (percent): True
     custom_content:
-        endogenous_dna: true
-        endogenous_dna_post: true
-        Num_SNPs: true
-        Method1_MOM_estimate: false
-        Method1_MOM_SE: false
-        Method1_ML_estimate: true
-        Method1_ML_SE: true
-        Method2_MOM_estimate: false
-        Method2_MOM_SE: false
-        Method2_ML_estimate: false
-        Method2_ML_SE: false
+        endogenous_dna: True
+        endogenous_dna_post: True
+    nuclear_contamination:
+        Num_SNPs: True
+        Method1_MOM_estimate: False
+        Method1_MOM_SE: False
+        Method1_ML_estimate: True
+        Method1_ML_SE: True
+        Method2_MOM_estimate: False
+        Method2_MOM_SE: False
+        Method2_ML_estimate: False
+        Method2_ML_SE: False
 
 table_columns_placement:
     FastQC (pre-AdapterRemoval):

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -105,6 +105,9 @@ qualimap_config:
         - 4
         - 5
 
+remove_sections:
+  - sexdeterrmine-snps
+
 table_columns_visible:
     FastQC (pre-AdapterRemoval):
         percent_duplicates: False

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -163,6 +163,18 @@ table_columns_visible:
         percentage_aligned: False
     MultiVCFAnalyzer:
         Heterozygous SNP alleles (percent): True
+    custom_content:
+        endogenous_dna: true
+        endogenous_dna_post: true
+        Num_SNPs: true
+        Method1_MOM_estimate: false
+        Method1_MOM_SE: false
+        Method1_ML_estimate: true
+        Method1_ML_SE: true
+        Method2_MOM_estimate: false
+        Method2_MOM_SE: false
+        Method2_ML_estimate: false
+        Method2_ML_SE: false
 
 table_columns_placement:
     FastQC (pre-AdapterRemoval):

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -234,7 +234,7 @@ table_columns_placement:
         RateX: 1000
         RateY: 1010
     MultiVCFAnalyzer:
-        Heterozygous SNP alleles (percent): 1100
+        Heterozygous SNP alleles (percent): 1200
 read_count_multiplier: 1
 read_count_prefix: ''
 read_count_desc: ''

--- a/bin/print_x_contamination.py
+++ b/bin/print_x_contamination.py
@@ -2,6 +2,7 @@
 import sys, re, json
 from collections import OrderedDict
 
+jsonOut=OrderedDict()
 data=OrderedDict()
 
 Input_files=sys.argv[1:]
@@ -26,7 +27,7 @@ for fn in Input_files:
                 err_mom1=fields[4].split(":")[1]
                 ml1=fields[5].split(":")[1]
                 err_ml1=fields[6].split(":")[1]
-                ## Sometimes angsd fails to run method 2, and the error is printed directly after the SE for ML. When that happens, exclude the first word in the error from the output. (Method 2 data will be shown as NA)
+                ## Sometimes angsd fails to run method 2, and the error is printed directly after the SE for ML. When that happens, exclude the first word in the error from the output. (Method 2 jsonOut will be shown as NA)
                 if err_ml1.endswith("contamination"):
                     err_ml1 = err_ml1[:-13]
             elif line.strip()[0:7] == "Method2" and line.strip()[9:16] == 'new_llh':
@@ -37,5 +38,20 @@ for fn in Input_files:
         data[Ind]={ "Number_of_SNPs" : nSNPs, "Method1_MOM_estimate" : mom1, "Method1_MOM_SE" : err_mom1, "Method1_ML_estimate" : ml1, "Method1_ML_SE" : err_ml1, "Method2_MOM_estimate" : mom2, "Method2_MOM_SE" : err_mom2, "Method2_ML_estimate" : ml2, "Method2_ML_SE" : err_ml2 }
         print (Ind, nSNPs, mom1, err_mom1, ml1, err_ml1, mom2, err_mom2, ml2, err_ml2, sep="\t", file=output)
 
+
+jsonOut = {"plot_type": "generalstats", 
+    "pconfig": {
+        "Num_SNPs" : {"title" : "Number of SNPs"},
+        "Method1_MOM_estimate" : {"title": "Contamination Estimate (M1_MOM)"},
+        "Method1_MOM_SE" : {"title": "Estimate Error (M1_MOM)"},
+        "Method1_ML_estimate" : {"title": "Contamination Estimate (M1_ML)"},
+        "Method1_ML_SE" : {"title": "Estimate Error (M1_ML)"},
+        "Method2_MOM_estimate" : {"title": "Contamination Estimate (M2_MOM)"},
+        "Method2_MOM_SE" : {"title": "Estimate Error (M2_MOM)"},
+        "Method2_ML_estimate" : {"title": "Contamination Estimate (M2_ML)"},
+        "Method2_ML_SE" : {"title": "Estimate Error (M2_ML)"}
+    }, 
+    "data" = data
+}
 with open('nuclear_contamination.json', 'w') as outfile:
-    json.dump(data, outfile)
+    json.dump(jsonOut, outfile)

--- a/bin/print_x_contamination.py
+++ b/bin/print_x_contamination.py
@@ -58,7 +58,7 @@ for fn in Input_files:
         print (Ind, nSNPs, mom1, err_mom1, ml1, err_ml1, mom2, err_mom2, ml2, err_ml2, sep="\t", file=output)
 
 
-jsonOut = {"plot_type": "generalstats", 
+jsonOut = {"plot_type": "generalstats", "id": "nuclear_contamination",
     "pconfig": {
         "Num_SNPs" : {"title" : "Number of SNPs"},
         "Method1_MOM_estimate" : {"title": "Contamination Estimate (Method1_MOM)"},

--- a/bin/print_x_contamination.py
+++ b/bin/print_x_contamination.py
@@ -51,7 +51,7 @@ jsonOut = {"plot_type": "generalstats",
         "Method2_ML_estimate" : {"title": "Contamination Estimate (M2_ML)"},
         "Method2_ML_SE" : {"title": "Estimate Error (M2_ML)"}
     }, 
-    "data" = data
+    "data" : data
 }
 with open('nuclear_contamination.json', 'w') as outfile:
     json.dump(jsonOut, outfile)

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - bioconda::kraken2=2.0.9beta
   - conda-forge::pandas=1.0.4 #.4 is python3.8+ compatible
   - bioconda::freebayes=1.3.2 #should be fine with python 3.8, but says <3.7 on webpage
-  - bioconda::sexdeterrmine=1.1.1
+  - bioconda::sexdeterrmine=1.1.2
   - bioconda::multivcfanalyzer=0.85.2
   - bioconda::hops=0.34
   - conda-forge::biopython=1.76

--- a/main.nf
+++ b/main.nf
@@ -2637,7 +2637,7 @@ process print_nuclear_contamination{
 
     output:
     file 'nuclear_contamination.txt'
-    file 'nuclear_contamination.json'
+    file 'nuclear_contamination_mqc.json' into ch_nuclear_contamination_for_multiqc
 
     script:
     """
@@ -2959,6 +2959,7 @@ process multiqc {
     file ('malt/*') from ch_malt_for_multiqc.collect().ifEmpty([])
     file ('kraken/*') from ch_kraken_for_multiqc.collect().ifEmpty([])
     file ('hops/*') from ch_hops_for_multiqc.collect().ifEmpty([])
+    file ('nuclear_contamination/*') from ch_nuclear_contamination_for_multiqc.collect().ifEmpty([])
     file logo from ch_eager_logo
 
     file workflow_summary from ch_workflow_summary.collectFile(name: "workflow_summary_mqc.yaml")

--- a/main.nf
+++ b/main.nf
@@ -2637,6 +2637,7 @@ process print_nuclear_contamination{
 
     output:
     file 'nuclear_contamination.txt'
+    file 'nuclear_contamination.json'
 
     script:
     """


### PR DESCRIPTION
Various changes:
 - Added latest version of Sex.DetERmine to `environment.yaml`. This version doesn't fail horribly when a bin has 0 coverage, instead setting the rates to 0.
 - Removed second barplot (`snp_counts`) from multiqc_report. Not that useful, but easier to hide it than to change MQC modules. 

Nuclear_contamination changes:
 - Added nuclear contamination JSON output into multiQC
 - Order of columns fixed so they come after SexDet.

To Do:
- [x] Hide non default columns from nuclear_contamination output.
- [ ] SampleID is not correctly assigned in some cases. When running with `-profile test_tsv_humanbam`, library entry is correctly assigned,but individual level entry has `_rmdup` added to Sample ID in the JSON. Looking into it.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated



