### PR TITLE
Endorspy update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Latest version of FreeBayes (1.3.2)
 * Latest version of xopen (0.9.0)
 * Added Bowtie 2 (2.4.1)
+* Latest version of endorS.py (0.3)
 
 ## [2.1.0] - 2020-03-05 - "Ravensburg"
 

--- a/bin/endorS.py
+++ b/bin/endorS.py
@@ -23,7 +23,7 @@ parser = argparse.ArgumentParser(prog='endorS.py',
    '''))
 parser.add_argument('samtoolsfiles', metavar='<samplefile>.stats', type=str, nargs='+',
                     help='output of samtools flagstat in a txt file (at least one required). If two files are supplied, the mapped reads of the second file is divided by the total reads in the first, since it assumes that the <samplefile.stats> are related to the same sample. Useful after BAM filtering')
-parser.add_argument('-v','--version', action='version', version='%(prog)s 0.2')
+parser.add_argument('-v','--version', action='version', version='%(prog)s 0.3')
 parser.add_argument('--output', '-o', nargs='?', help='specify a file format for an output file. Options: <json> for a MultiQC json output. Default: none')
 parser.add_argument('--name', '-n', nargs='?', help='specify name for the output file. Default: extracted from the first samtools flagstat file provided')
 args = parser.parse_args()
@@ -37,7 +37,14 @@ try:
     #Extract number of mapped reads pre-quality filtering:
     mappedPre = float((re.findall(r'([0-9]+) \+ [0-9]+ mapped ',contentsPre))[0])
     #Calculation of endogenous DNA pre-quality filtering:
-    endogenousPre = float("{0:.2f}".format(round((mappedPre / totalReads * 100), 2)))
+    if totalReads == 0.0:
+        endogenousPre = 0.000000
+        print("WARNING: no reads in the fastq input, Endogenous DNA raw (%) set to 0.000000")
+    elif mappedPre == 0.0:
+        endogenousPre = 0.000000
+        print("WARNING: no mapped reads, Endogenous DNA raw (%) set to 0.000000")
+    else:
+        endogenousPre = float("{0:.6f}".format(round((mappedPre / totalReads * 100), 6)))
 except:
     print("Incorrect input, please provide at least a samtools flag stats as input\nRun:\npython endorS.py --help \nfor more information on how to run this script")
     sys.exit()
@@ -49,7 +56,14 @@ try:
     #Extract number of mapped reads post-quality filtering:
     mappedPost = float((re.findall(r'([0-9]+) \+ [0-9]+ mapped',contentsPost))[0])
     #Calculation of endogenous DNA post-quality filtering:
-    endogenousPost = float("{0:.2f}".format(round((mappedPost / totalReads * 100),2)))
+    if totalReads == 0.0:
+        endogenousPost = 0.000000
+        print("WARNING: no reads in the fastq input, Endogenous DNA modified (%) set to 0.000000")
+    elif mappedPost == 0.0:
+        endogenousPost = 0.000000
+        print("WARNING: no mapped reads, Endogenous DNA modified (%) set to 0.000000")
+    else:
+        endogenousPost = float("{0:.6f}".format(round((mappedPost / totalReads * 100),6)))
 except:
     print("Only one samtools flagstat file provided")
     #Set the number of reads post-quality filtering to 0 if samtools
@@ -68,9 +82,10 @@ else:
 if mappedPost == "NA":
     #Creating the json file
     jsonOutput={
+    "id": "endorS.py ",
     "plot_type": "generalstats",
     "pconfig": {
-        "endogenous_dna": { "max": 100, "min": 0, "title": "Endogenous DNA (%)"}
+        "endogenous_dna": { "max": 100, "min": 0, "title": "Endogenous DNA (%)", "format": '{:,.2f}'}
     },
     "data": {
         name : { "endogenous_dna": endogenousPre}
@@ -79,14 +94,15 @@ if mappedPost == "NA":
 else:
     #Creating the json file
     jsonOutput={
+    "id": "endorS.py ",
     "plot_type": "generalstats",
     "pconfig": {
-        "endogenous_dna": { "max": 100, "min": 0, "title": "Endogenous DNA (%)"},
-        "endogenous_dna_post": { "max": 100, "min": 0, "title": "Endogenous DNA Post (%)"}
+        "endogenous_dna": { "max": 100, "min": 0, "title": "Endogenous DNA (%)", "format": '{:,.2f}'},
+        "endogenous_dna_post": { "max": 100, "min": 0, "title": "Endogenous DNA Post (%)", "format": '{:,.2f}'}
     },
     "data": {
         name : { "endogenous_dna": endogenousPre, "endogenous_dna_post": endogenousPost}
-    }
+    },
     }
 #Checking for print to screen argument:
 if args.output is not None:


### PR DESCRIPTION
# nf-core/eager pull request

Updated version of endorS.py related to issue #492, increases decimals in multiQC Report and adds check when no reads in input fastq and no mapped reads in bam file

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [x] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
