### PR TITLE
Add base exit codes to try to labelled process settings

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -82,22 +82,22 @@ process {
 
   // Add 141 ignore due to unclean pipe closing by pmdtools https://github.com/pontussk/PMDtools/issues/7
   withName: pmdtools {
-    errorStrategy = { task.exitStatus in [141] ? 'ignore' : 'retry' }
+    errorStrategy = { task.exitStatus in [143,137,104,134,139,141] ? 'ignore' : 'retry' }
   }
 
   // Add 1 retry for certain java tools as not enough heap space java errors gives exit code 1
   withName: dedup {
-    errorStrategy = { task.exitStatus in [1] ? 'retry' : 'finish' } 
+    errorStrategy = { task.exitStatus in [1,143,137,104,134,139] ? 'retry' : 'finish' } 
   }
 
   // Add 1 retry as not enough heapspace java error gives exit code 1
   withName: malt {
-    errorStrategy = { task.exitStatus in [1] ? 'retry' : 'finish' } 
+    errorStrategy = { task.exitStatus in [1,143,137,104,134,139] ? 'retry' : 'finish' } 
   }
 
   // other process specific exit statuses
   withName: nuclear_contamination {
-    errorStrategy = { task.exitStatus in [134] ? 'ignore' : 'retry' }
+    errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'ignore' : 'retry' }
   }
 
   withName: multiqc {


### PR DESCRIPTION
# nf-core/eager pull request

I learnt that process specific resource parameters _overwrite_ entirely any default settings and do not inherit. This ensures all eager specific process settings also have the default 'global ones'.

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
