### PR TITLE
Tsv headername validation

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -590,7 +590,7 @@ if (tsv_path) {
     tsv_file = file(tsv_path)
     if (!tsv_file.exists()) exit 1, "[nf-core/eager] error: input TSV file could not be found. Does the file exist or in the right place? You gave the path: ${params.input}"
 
-    ch_input_sample = extract_data(tsv_file)
+    ch_input_sample = extract_data(tsv_path)
 
 } else if (params.input && !has_extension(params.input, "tsv")) {
 
@@ -3359,13 +3359,13 @@ def checkHostname() {
 
 // Channelling the TSV file containing FASTQ or BAM 
 def extract_data(tsvFile) {
-    Channel.from(tsvFile)
+    Channel.fromPath(tsvFile)
         .splitCsv(header: true, sep: '\t')
+        .dump()
         .map { row ->
 
-            def expected_keys = ['Sample_Name', 'Library_ID', 'Lane', 'Color_Chemistry', 'SeqType', 'Organism', 'Strandedness', 'UDG_Treatment', 'R1', 'R2', 'BAM']
-            if ( !row.keySet().containsAll(expected_keys) ) exit 1, "[nf-core/eager] error: Invalid TSV input - malformed column names. Please check input TSV. Column names should be ${expected keys}"
-            println(!row.keySet().containsAll(expected_keys))
+            def expected_keys = ['Sample_Name', 'Library_ID', 'Lane', 'Colour_Chemistry', 'SeqType', 'Organism', 'Strandedness', 'UDG_Treatment', 'R1', 'R2', 'BAM']
+            if ( !row.keySet().containsAll(expected_keys) ) exit 1, "[nf-core/eager] error: Invalid TSV input - malformed column names. Please check input TSV. Column names should be: ${expected_keys.join(", ")}"
 
             checkNumberOfItem(row, 11)
 

--- a/main.nf
+++ b/main.nf
@@ -3358,12 +3358,17 @@ def checkHostname() {
 }
 
 // Channelling the TSV file containing FASTQ or BAM 
-// Header Format is: "Sample_Name  Library_ID  Lane  SeqType  Organism  Strandedness  UDG_Treatment  R1  R2  BAM  BAM_Index Group  Populations  Age"
 def extract_data(tsvFile) {
     Channel.from(tsvFile)
         .splitCsv(header: true, sep: '\t')
         .map { row ->
+
+            def expected_keys = ['Sample_Name', 'Library_ID', 'Lane', 'Color_Chemistry', 'SeqType', 'Organism', 'Strandedness', 'UDG_Treatment', 'R1', 'R2', 'BAM']
+            if ( !row.keySet().containsAll(expected_keys) ) exit 1, "[nf-core/eager] error: Invalid TSV input - malformed column names. Please check input TSV. Column names should be ${expected keys}"
+            println(!row.keySet().containsAll(expected_keys))
+
             checkNumberOfItem(row, 11)
+
             def samplename = row.Sample_Name
             def libraryid  = row.Library_ID
             def lane = row.Lane


### PR DESCRIPTION
# nf-core/eager pull request

Due to insufficient validation, if there was a typo name in a column (e.g. Color vs Colour), the corresponding column would evaluated as 'NULL' for every row and mess up downstream analyses. This adds a check that all columns headers are named correctly. This should close #541 

## PR checklist

- [x] This comment contains a description of changes (with reason)  (not necessary)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)  (not necessary)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [x] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated (not necessary)
- [x] `README.md` is updated (not necessary)

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
