### PR TITLE
Replaced awk with python version of read filtering

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1809,11 +1809,10 @@ process samtools_filter {
         samtools view -h -b !{bam} -@ !{task.cpus} -q !{params.bam_mapping_quality_threshold} -o tmp_mapped.bam
 
         ## Mapped LEN filtering
-        if [[ !{minlength} -eq 0 ]]; then
+        if [[ !{params.bam_filter_minreadlength} -eq 0 ]]; then
             mv tmp_mapped.bam !{libraryid}.filtered.bam
         else
-            ## From https://www.biostars.org/p/92889/#92908; note may not be optimal for un-merged reads (i.e. reads with long fragment lenths)
-            samtools view -h tmp_mapped.bam | awk 'length($10) >= !{minlength} || $1 ~ /^@/' | samtools view -bS - > !{libraryid}.filtered.bam
+            filter_bam_fragment_length.py -a -l !{params.bam_filter_minreadlength} -o !{libraryid} tmp_mapped.bam
         fi
 
         samtools index !{libraryid}.filtered.bam !{size}
@@ -1827,8 +1826,7 @@ process samtools_filter {
         if [[ !{params.bam_filter_minreadlength} -eq 0 ]]; then
             mv tmp_mapped.bam !{libraryid}.filtered.bam
         else
-            ## From https://www.biostars.org/p/92889/#92908; note may not be optimal for un-merged reads (i.e. reads with long fragment lenths)
-            samtools view -h tmp_mapped.bam | awk 'length($10) >= !{params.bam_filter_minreadlength} || $1 ~ /^@/' | samtools view -bS - > !{libraryid}.filtered.bam
+            filter_bam_fragment_length.py -a -l !{params.bam_filter_minreadlength} -o !{libraryid} tmp_mapped.bam
         fi
 
         samtools index !{libraryid}.filtered.bam !{size}
@@ -1843,8 +1841,7 @@ process samtools_filter {
         if [[ !{params.bam_filter_minreadlength} -eq 0 ]]; then
             mv tmp_mapped.bam !{libraryid}.filtered.bam
         else
-            ## From https://www.biostars.org/p/92889/#92908; note may not be optimal for un-merged reads (i.e. reads with long fragment lenths)
-            samtools view -h tmp_mapped.bam | awk 'length($10) >= !{params.bam_filter_minreadlength} || $1 ~ /^@/' | samtools view -bS - > !{libraryid}.filtered.bam
+            filter_bam_fragment_length.py -a -l !{params.bam_filter_minreadlength} -o !{libraryid} tmp_mapped.bam
         fi
 
         samtools index !{libraryid}.filtered.bam !{size}
@@ -1859,8 +1856,7 @@ process samtools_filter {
         if [[ !{params.bam_filter_minreadlength} -eq 0 ]]; then
             mv tmp_mapped.bam !{libraryid}.filtered.bam
         else
-            ## From https://www.biostars.org/p/92889/#92908; note may not be optimal for un-merged reads (i.e. reads with long fragment lenths)
-            samtools view -h tmp_mapped.bam | awk 'length($10) >= !{params.bam_filter_minreadlength} || $1 ~ /^@/' | samtools view -bS - > !{libraryid}.filtered.bam
+            filter_bam_fragment_length.py -a -l !{params.bam_filter_minreadlength} -o !{libraryid} tmp_mapped.bam
         fi
 
         samtools index !{libraryid}.filtered.bam !{size}
@@ -1879,8 +1875,7 @@ process samtools_filter {
         if [[ !{params.bam_filter_minreadlength} -eq 0 ]]; then
             mv tmp_mapped.bam !{libraryid}.filtered.bam
         else
-            ## From https://www.biostars.org/p/92889/#92908; note may not be optimal for un-merged reads (i.e. reads with long fragment lenths)
-            samtools view -h tmp_mapped.bam | awk 'length($10) >= !{params.bam_filter_minreadlength} || $1 ~ /^@/' | samtools view -bS - > !{libraryid}.filtered.bam
+            filter_bam_fragment_length.py -a -l !{params.bam_filter_minreadlength} -o !{libraryid} tmp_mapped.bam
         fi
 
         samtools index !{libraryid}.filtered.bam !{size}


### PR DESCRIPTION
# nf-core/eager pull request

This is to address the instability of the awk command that occurs during CI testing, by replacing it with @maxibor 's python script.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [x] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated (not necessary as already new addition in this release)
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
