### PR TITLE
Bugfix. Corrected number of relevant SNPs and NAs in `print_x_contamination.py`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Nuclear contamination is now reported with the correct library names.
 * Merged all tutorials and FAQs into `usage.md` for display on nf-co.re
 * Corrected header of nuclear contamination table (`nuclear_contamination.txt`).
+* Fixed a bug with `nSNPs` definition in `print_x_contamination.py`. Number of SNPs now correctly reported.
+* `print_x_contamination.py` now correctly converts all NA values to "N/A".
 
 ### `Dependencies`
 

--- a/bin/print_x_contamination.py
+++ b/bin/print_x_contamination.py
@@ -7,7 +7,7 @@ data=OrderedDict()
 
 ## Function to convert a set of elements into floating point numbers, when possible, else leave them be.
 def make_float(x):
-    print (x)
+    # print (x)
     output=[None for i in range(len(x))]
     ## If value for an estimate/error is -nan, replace with "NA". JSON does not accept NaN as a valid field.
     for i in range(len(x)):

--- a/bin/print_x_contamination.py
+++ b/bin/print_x_contamination.py
@@ -11,7 +11,7 @@ def make_float(x):
     output=[None for i in range(len(x))]
     ## If value for an estimate/error is -nan, replace with "NA". JSON does not accept NaN as a valid field.
     for i in range(len(x)):
-        if x[i] == "-nan":
+        if x[i] == "-nan" or x[i] == "nan":
             output[i]="N/A"
             continue
         try:
@@ -32,13 +32,14 @@ for fn in Input_files:
     ml1, err_ml1="N/A","N/A"
     mom2, err_mom2= "N/A","N/A"
     ml2, err_ml2="N/A","N/A"
+    nSNPs="0"
     with open(fn, 'r') as f:
         Estimates={}
         Ind=re.sub('\.X.contamination.out$', '', fn).split("/")[-1]
         for line in f:
             fields=line.strip().split()
-            if line.strip()[0:21] == "[readicnts] Has read:":
-                nSNPs=fields[4]
+            if line.strip()[0:19] == "We have nSNP sites:":
+                nSNPs=fields[4].rstrip(",")
             elif line.strip()[0:7] == "Method1" and line.strip()[9:16] == 'new_llh':
                 mom1=fields[3].split(":")[1]
                 err_mom1=fields[4].split(":")[1]


### PR DESCRIPTION
Bugfix in definition of `nSNPs` within `print_x_contamination.py`. 
Coercion of `nan` and `-nan` to `N/A` for more consistent MultiQC table reporting.
Corrected the reported number of SNPs used for nuclear contamination to be in line with the output of the latest ANGSD version.

This PR correctly references the `dev` branch. 
 
## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] `CHANGELOG.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
