### PR TITLE
Added check only single TSV is supplied.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -601,7 +601,8 @@ and samples.
 The use of the TSV `--input` method is recommended to be used when performing
 more complex procedures such as lane or library merging. You do not need to
 specify `--single_end`, `--bam`, `--colour_chemistry`, `-udg_type` etc. when
-using TSV input - this is defined within the TSV file itself.
+using TSV input - this is defined within the TSV file itself. You can only
+supply a single TSV per run (i.e. `--input '*.tsv'` will not work).
 
 This TSV should look like the following:
 

--- a/main.nf
+++ b/main.nf
@@ -588,6 +588,8 @@ ch_input_sample = Channel.empty()
 if (tsv_path) {
 
     tsv_file = file(tsv_path)
+    
+    if (tsv_file instanceof List) exit 1, "[nf-core/eager] error: can only accept one TSV file per run."
     if (!tsv_file.exists()) exit 1, "[nf-core/eager] error: input TSV file could not be found. Does the file exist or in the right place? You gave the path: ${params.input}"
 
     ch_input_sample = extract_data(tsv_path)


### PR DESCRIPTION
# nf-core/eager pull request

This adds a validation check that only a single TSV is supplied (i.e. restricts the use of `*.tsv` to prevent scary groovy errors).

This closes #551 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
