### PR TITLE
Bump MultiQC resources for cases of >1000 samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Corrected header of nuclear contamination table (`nuclear_contamination.txt`).
 * Fixed a bug with `nSNPs` definition in `print_x_contamination.py`. Number of SNPs now correctly reported.
 * `print_x_contamination.py` now correctly converts all NA values to "N/A".
+* Increased amount of memory MultiQC by default uses, to account for very large nf-core/eager runs (e.g. >1000 samples).
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -3151,7 +3151,7 @@ process get_software_versions {
 // MultiQC file generation for pipeline report
 
 process multiqc {
-    label 'sc_small'
+    label 'sc_medium'
 
     publishDir "${params.outdir}/multiqc", mode: params.publish_dir_mode
 


### PR DESCRIPTION
# nf-core/eager pull request

Privately reported issue where MultiQC craps out with exit code 1 when running with >1000 samples. Not sure why the error occurs atm, but as a quick work around I propose to bump resources to give MQC at least 8GB.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [x] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
