### PR TITLE
Script licenses

### DIFF
--- a/bin/endorS.py
+++ b/bin/endorS.py
@@ -4,7 +4,7 @@
 # See git repository (https://github.com/aidaanva/endorS.py) for full license text.
 
 """Script to calculate the endogenous DNA in a sample from samtools flag stats.
-It accepts can accept up to two files: pre-quality and post-quality filtering. We recommend
+It can accept up to two files: pre-quality and post-quality filtering. We recommend
 to use both files but you can also use the pre-quality filtering.
 """
 import re

--- a/bin/endorS.py
+++ b/bin/endorS.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Written by Aida Andrades Valtueña and released under GPL v3 license. 
+# See git repository (https://github.com/aidaanva/endorS.py) for full license text.
+
 """Script to calculate the endogenous DNA in a sample from samtools flag stats.
 It accepts can accept up to two files: pre-quality and post-quality filtering. We recommend
 to use both files but you can also use the pre-quality filtering.

--- a/bin/extract_map_reads.py
+++ b/bin/extract_map_reads.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Written by Maxime Borry and released under the MIT license. 
+# See git repository (https://github.com/nf-core/eager) for full license text.
+
 import argparse
 import multiprocessing
 import pysam

--- a/bin/filter_bam_fragment_length.py
+++ b/bin/filter_bam_fragment_length.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Written by Maxime Borry and released under the MIT license. 
+# See git repository (https://github.com/nf-core/eager) for full license text.
+
 import argparse
 import pysam
 

--- a/bin/kraken_parse.py
+++ b/bin/kraken_parse.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+# Written by Maxime Borry and released under the MIT license. 
+# See git repository (https://github.com/nf-core/eager) for full license text.
 
 import argparse
 import csv
-
 
 def _get_args():
     '''This function parses and return arguments passed in'''

--- a/bin/merge_kraken_res.py
+++ b/bin/merge_kraken_res.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
+# Written by Maxime Borry and released under the MIT license. 
+# See git repository (https://github.com/nf-core/eager) for full license text.
+
 import argparse
 import os
 import pandas as pd
 import numpy as np
-
 
 def _get_args():
     '''This function parses and return arguments passed in'''

--- a/bin/parse_snp_cov.py
+++ b/bin/parse_snp_cov.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Written by Thiseas C. Lamnidis and released under the MIT license. 
+# See git repository (https://github.com/nf-core/eager) for full license text.
+
 import sys, json
 from collections import OrderedDict
 

--- a/bin/print_x_contamination.py
+++ b/bin/print_x_contamination.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Written by Thiseas C. Lamnidis and released under the MIT license. 
+# See git repository (https://github.com/nf-core/eager) for full license text.
+
 import sys, re, json
 from collections import OrderedDict
 


### PR DESCRIPTION
# nf-core/eager pull request

Something I noted when reviewing nf-core/cageseq, is that some of the utility scripts might be useful outside of eager2 at points, so it is good to insert the author and a (short) version of the license in each of them.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [x] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
