### PR TITLE
Circular mapper fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed AWS full test profile.
 - [#587](https://github.com/nf-core/eager/issues/587) - Re-implemented AdapterRemovalFixPrefix for DeDup compatibility of including singletons
+- [#610](https://github.com/nf-core/eager/issues/610) - Create bwa_index channel when specifying circularmapper as mapper
 
 ## [2.2.1] - 2020-10-20
 

--- a/main.nf
+++ b/main.nf
@@ -328,7 +328,7 @@ if (params.bt2n != 0 && params.bt2n != 1) {
 }
 
 // Index files provided? Then check whether they are correct and complete
-if( params.bwa_index != '' && (params.mapper == 'bwaaln' | params.mapper == 'bwamem')){
+if( params.bwa_index != '' && (params.mapper == 'bwaaln' | params.mapper == 'bwamem' | params.mapper == 'circularmapper')){
     Channel
         .fromPath(params.bwa_index, checkIfExists: true)
         .ifEmpty { exit 1, "[nf-core/eager] error: bwa indices not found in: ${index_base}." }


### PR DESCRIPTION
# nf-core/eager pull request

Makes sure a bwa_index channel is made when specifyin circularmapper, to close #610 

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --paired_end`).
- [ ] Make sure your code lints ([`nf-core lint .`](https://nf-co.re/tools)).
- [x] Documentation in `docs` is updated
- [x] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
