### PR TITLE
Min nf bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['20.04.0', '']
+        nxf_ver: ['20.07.1', '']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
 
       - name: Build new docker image
         if: env.MATCHED_FILES
-        run: docker build --no-cache . -t nfcore/eager:2.3.1
+        run: docker build --no-cache . -t nfcore/eager:dev
 
       - name: Pull docker image
         if: ${{ !env.MATCHED_FILES }}
         run: |
           docker pull nfcore/eager:dev
-          docker tag nfcore/eager:dev nfcore/eager:2.3.1
+          docker tag nfcore/eager:dev nfcore/eager:dev
 
       - name: Install Nextflow
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [dev] - unreleased
+
+### `Added`
+
+### `Fixed`
+
+### `Dependencies`
+
+### `Deprecated`
+
 ## [2.3.1] - 2021-01-14
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 
+- [#631](https://github.com/nf-core/eager/issues/631): - Update minimum Nextflow version to 20.07.1, due to unfortunate bug in Nextflow 20.04.1 causing eager to crash if patch pulled
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ COPY environment.yml /
 RUN conda env create --quiet -f /environment.yml && conda clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/nf-core-eager-2.3.1/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-eager-2.3.2dev/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name nf-core-eager-2.3.1 > nf-core-eager-2.3.1.yml
+RUN conda env export --name nf-core-eager-2.3.2dev > nf-core-eager-2.3.2dev.yml
 
 # Instruct R processes to use these empty files instead of clashing with a local version
 RUN touch .Rprofile

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![GitHub Actions CI Status](https://github.com/nf-core/eager/workflows/nf-core%20CI/badge.svg)](https://github.com/nf-core/eager/actions)
 [![GitHub Actions Linting Status](https://github.com/nf-core/eager/workflows/nf-core%20linting/badge.svg)](https://github.com/nf-core/eager/actions)
-[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A520.04.0-brightgreen.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A520.07.1-brightgreen.svg)](https://www.nextflow.io/)
 [![nf-core](https://img.shields.io/badge/nf--core-pipeline-brightgreen.svg)](https://nf-co.re/)
 [![DOI](https://zenodo.org/badge/135918251.svg)](https://zenodo.org/badge/latestdoi/135918251)
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-eager-2.3.1
+name: nf-core-eager-2.3.2dev
 channels:
   - conda-forge
   - bioconda

--- a/nextflow.config
+++ b/nextflow.config
@@ -251,7 +251,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nfcore/eager:2.3.1'
+process.container = 'nfcore/eager:dev'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -345,7 +345,7 @@ manifest {
   description = 'A fully reproducible and state-of-the-art ancient DNA analysis pipeline'
   mainScript = 'main.nf'
   nextflowVersion = '!>=20.04.0'
-  version = '2.3.1'
+  version = '2.3.2dev'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/nextflow.config
+++ b/nextflow.config
@@ -344,7 +344,7 @@ manifest {
   homePage = 'https://github.com/nf-core/eager'
   description = 'A fully reproducible and state-of-the-art ancient DNA analysis pipeline'
   mainScript = 'main.nf'
-  nextflowVersion = '!>=20.04.0'
+  nextflowVersion = '!>=20.07.1'
   version = '2.3.2dev'
 }
 


### PR DESCRIPTION
Identified when looking at AWS test results: AWS pulls 20.04.1 which had a bug with nested-Nf parameters. Although 20.04.0 worked, .1 doesn't so we need to jump to the next stable release (20.07.1).

to close #631 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
