### PR TITLE
Added exit code 140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#673](https://github.com/nf-core/eager/pull/673) Fix Kraken database loading when loading from directory instead of compressed file.
 - [#688](https://github.com/nf-core/eager/issues/668) - Allow pipeline to complete, even if Qualimap crashes due to an empty or corrupt BAM file for one sample/library
 - [#683](https://github.com/nf-core/eager/pull/683) - Sets `--igenomes_ignore` to true by default, as rarely used by users currently and makes resolving configs less complex.
+- Added exit code `140` to re-tryable exit code list to account for certain scheduler wall-time limit fails.
 
 ### `Dependencies`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -14,7 +14,7 @@ process {
   memory = { check_max( 7.GB * task.attempt, 'memory' ) }
   time = { check_max( 24.h * task.attempt, 'time' ) }
 
-  errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+  errorStrategy = { task.exitStatus in [143,137,104,134,139, 140] ? 'retry' : 'finish' }
   maxRetries = 3
   maxErrors = '-1'
 
@@ -74,7 +74,7 @@ process {
   }
 
   withName:qualimap{
-    errorStrategy = { task.exitStatus in [1,143,137,104,134,139] ? 'retry' : task.exitStatus in [255] ? 'ignore' : 'finish' }
+    errorStrategy = { task.exitStatus in [1,143,137,104,134,139, 140] ? 'retry' : task.exitStatus in [255] ? 'ignore' : 'finish' }
   }
 
   withName:preseq {
@@ -82,26 +82,26 @@ process {
   }
 
   withName:damageprofiler {
-    errorStrategy = { task.exitStatus in [1,143,137,104,134,139] ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in [1,143,137,104,134,139, 140] ? 'retry' : 'finish' }
   }
 
   // Add 1 retry for certain java tools as not enough heap space java errors gives exit code 1
   withName: dedup {
-    errorStrategy = { task.exitStatus in [1,143,137,104,134,139] ? 'retry' : 'finish' } 
+    errorStrategy = { task.exitStatus in [1,143,137,104,134,139, 140] ? 'retry' : 'finish' } 
   }
   
   withName: markduplicates {
-    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'finish' } 
+    errorStrategy = { task.exitStatus in [143,137, 140] ? 'retry' : 'finish' } 
   }
 
   // Add 1 retry as not enough heapspace java error gives exit code 1
   withName: malt {
-    errorStrategy = { task.exitStatus in [1,143,137,104,134,139] ? 'retry' : 'finish' } 
+    errorStrategy = { task.exitStatus in [1,143,137,104,134,139, 140] ? 'retry' : 'finish' } 
   }
 
   // other process specific exit statuses
   withName: nuclear_contamination {
-    errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'ignore' : 'retry' }
+    errorStrategy = { task.exitStatus in [143,137,104,134,139, 140] ? 'ignore' : 'retry' }
   }
 
 }


### PR DESCRIPTION
This PR adds exit code 140 for retry, which for a variety of schedulers (in particular *grid engine related), corresponds to a walltime limit-kill. 

e.g. 
https://sites.google.com/a/case.edu/hpcc/jobs/slurm-command-overview/exit-code-status
https://users.gridengine.narkive.com/ZyRamWD7/gridengine-users-exit-status-140

Reported by Megan Michel at SHH/EVA/Harvard.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
 - [x] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
