### PR TITLE
Temporarily specify tbb library to get funtional bowtie2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -49,4 +49,5 @@ dependencies:
   - bioconda::eigenstratdatabasetools=1.0.2
   - bioconda::mapdamage2=2.2.0
   - bioconda::bbmap=38.87
+  - conda-forge::tbb=2020.02 # temp for bioconda broken bowtie2, remove once patched in bioconda
 


### PR DESCRIPTION
As suggested by one of the bioconda gods: https://twitter.com/dpryan79/status/1368116490801717251

Hopefully should fix the broken bowtie2 CI tests

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
