### PR TITLE
Multiqc message on completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Added`
 
+- [https://github.com/nf-core/eager/issues/736] - Add printing of multiqc run report location on successful completion
+
 ### `Fixed`
 
 ### `Dependencies`

--- a/lib/NfcoreSchema.groovy
+++ b/lib/NfcoreSchema.groovy
@@ -259,7 +259,7 @@ class NfcoreSchema {
         return new_params
     }
 
-     /*
+    /*
      * This method tries to read a JSON params file
      */
     private static LinkedHashMap params_load(String json_schema) {

--- a/main.nf
+++ b/main.nf
@@ -3128,6 +3128,7 @@ workflow.onComplete {
 
     if (workflow.success) {
         log.info "-${c_purple}[nf-core/eager]${c_green} Pipeline completed successfully${c_reset}-"
+        log.info "-${c_purple}[nf-core/eager]${c_green} MultiQC run report can be found in ${params.outdir}/multiqc ${c_reset}-"
     } else {
         checkHostname()
         log.info "-${c_purple}[nf-core/eager]${c_red} Pipeline completed with errors${c_reset}-"


### PR DESCRIPTION
This simply helps users who might be initially overwhelmed by the number of output directories where to find their multiqc report. 

To close #736 

:warning: Merge #742 first!

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
