### PR TITLE
Update best practise defults and bam trimming defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#771](https://github.com/nf-core/eager/issues/771) Remove legacy code
 - Improved output documentation for MultiQC general stats table (thanks to @KathrinNaegele and @esalmela)
 - Improved output documentation for BowTie2 (thanks to @isinaltinkaya)
+- [#612](https://github.com/nf-core/eager/issues/612) Updated BAM trimming defaults to 0 to ensure no unwanted trimming when mixing half-UDG with no-UDG (thanks to @scarlhoff)
+- [#722](https://github.com/nf-core/eager/issues/722) Updated BWA mapping mapping parameters to latest recommendations - primarily alnn back to 0.01 and aln0 to 2 as per Oliva et al. 2021 (10.1093/bib/bbab076)
 
 ### `Dependencies`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -83,10 +83,10 @@ params {
 
   //Mapping algorithm
   mapper = 'bwaaln'
-  bwaalnn = 0.04
+  bwaalnn = 0.01 // From Oliva et al. 2021 (10.1093/bib/bbab076)
   bwaalnk = 2
-  bwaalnl = 1024 // From Schubert et al. 2012 (10.1186/1471-2164-13-178)
-  bwaalno = 1 // leave at bwa default for now
+  bwaalnl = 1024 // From Oliva et al. 2021 (10.1093/bib/bbab076)
+  bwaalno = 2 // From Oliva et al. 2021 (10.1093/bib/bbab076)
   circularextension = 500
   circulartarget = 'MT'
   circularfilter = false
@@ -144,10 +144,10 @@ params {
 
   //bamUtils trimbam settings
   run_trim_bam = false 
-  bamutils_clip_half_udg_left = 1 
-  bamutils_clip_half_udg_right = 1 
-  bamutils_clip_none_udg_left = 1 
-  bamutils_clip_none_udg_right = 1 
+  bamutils_clip_half_udg_left = 0
+  bamutils_clip_half_udg_right = 0 
+  bamutils_clip_none_udg_left = 0
+  bamutils_clip_none_udg_right = 0 
   bamutils_softclip = false
 
   //Genotyping options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -577,7 +577,7 @@
                 },
                 "bwaalnn": {
                     "type": "number",
-                    "default": 0.04,
+                    "default": 0.01,
                     "description": "Specify the -n parameter for BWA aln, i.e. amount of allowed mismatches in the alignment.",
                     "fa_icon": "fas fa-sort-numeric-down",
                     "help_text": "Configures the `bwa aln -n` parameter, defining how many mismatches are allowed in a read. By default set to `0.04` (following recommendations of [Schubert et al. (2012 _BMC Genomics_)](https://doi.org/10.1186/1471-2164-13-178)), if you're uncertain what to set check out [this](https://apeltzer.shinyapps.io/bwa-mismatches/) Shiny App for more information on how to set this parameter efficiently.\n\n> Modifies bwa aln parameter: `-n`"
@@ -598,7 +598,7 @@
                 },
                 "bwaalno": {
                     "type": "integer",
-                    "default": 1,
+                    "default": 2,
                     "fa_icon": "fas fa-people-arrows",
                     "description": "Specify the -o parameter for BWA aln i.e. the number of gaps allowed.",
                     "help_text": "Configures the number of gaps used in `bwa aln`. Default is set to `bwa` default.\n\n> Modifies BWA aln parameter: `-o`\n"
@@ -966,28 +966,28 @@
                 },
                 "bamutils_clip_half_udg_left": {
                     "type": "integer",
-                    "default": 1,
+                    "default": 0,
                     "fa_icon": "fas fa-ruler-combined",
                     "description": "Specify the number of bases to clip off reads from 'left' end of read for half-UDG libraries.",
                     "help_text": "Default set to `1` and clips off one base of the left or right side of reads from libraries whose UDG treatment is set to `half`. Note that reverse reads will automatically be clipped off at the reverse side with this (automatically reverses left and right for the reverse read).\n\n> Modifies bamUtil's trimBam parameter: `-L -R`"
                 },
                 "bamutils_clip_half_udg_right": {
                     "type": "integer",
-                    "default": 1,
+                    "default": 0,
                     "fa_icon": "fas fa-ruler",
                     "description": "Specify the number of bases to clip off reads from 'right' end of read for half-UDG libraries.",
                     "help_text": "Default set to `1` and clips off one base of the left or right side of reads from libraries whose UDG treatment is set to `half`. Note that reverse reads will automatically be clipped off at the reverse side with this (automatically reverses left and right for the reverse read).\n\n> Modifies bamUtil's trimBam parameter: `-L -R`"
                 },
                 "bamutils_clip_none_udg_left": {
                     "type": "integer",
-                    "default": 1,
+                    "default": 0,
                     "fa_icon": "fas fa-ruler-combined",
                     "description": "Specify the number of bases to clip off reads from 'left' end of read for non-UDG libraries.",
                     "help_text": "Default set to `1` and clips off one base of the left or right side of reads from libraries whose UDG treatment is set to `none`. Note that reverse reads will automatically be clipped off at the reverse side with this (automatically reverses left and right for the reverse read).\n\n> Modifies bamUtil's trimBam parameter: `-L -R`"
                 },
                 "bamutils_clip_none_udg_right": {
                     "type": "integer",
-                    "default": 1,
+                    "default": 0,
                     "fa_icon": "fas fa-ruler",
                     "description": "Specify the number of bases to clip off reads from 'right' end of read for non-UDG libraries.",
                     "help_text": "Default set to `1` and clips off one base of the left or right side of reads from libraries whose UDG treatment is set to `none`. Note that reverse reads will automatically be clipped off at the reverse side with this (automatically reverses left and right for the reverse read).\n\n> Modifies bamUtil's trimBam parameter: `-L -R`"


### PR DESCRIPTION
This sets bamutils trimming defaults to 0, and updates bwa aln mapping to best practices

To close #612 and to close #722 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [x] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [x] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
