### PR TITLE
Flexible filtering of reads for pileupcaller genotyping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Added`
 
- - [#808](https://github.com/nf-core/eager/issues/808) Retain read group information across bam merges. Sample set to Sample name in bwa output RG.
- - Map and base quality filters prior to genotyping with pileupcaller can now be specified.
+- [#808](https://github.com/nf-core/eager/issues/808) Retain read group information across bam merges. Sample set to Sample name in bwa output RG.
+- Map and base quality filters prior to genotyping with pileupcaller can now be specified.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Added`
 
  - [#808](https://github.com/nf-core/eager/issues/808) Retain read group information across bam merges. Sample set to Sample name in bwa output RG.
+ - Map and base quality filters prior to genotyping with pileupcaller can now be specified.
 
 ### `Fixed`
 

--- a/main.nf
+++ b/main.nf
@@ -2488,10 +2488,13 @@ process genotyping_pileupcaller {
   def ssmode = strandedness == "single" ? "--singleStrandMode" : ""
   def bam_list = bam.flatten().join(" ")
   def sample_names = samplename.flatten().join(",")
+  def map_q = params.pileupcaller_min_map_quality
+  def base_q = params.pileupcaller_min_base_quality
+
   """
-  samtools mpileup -B -q 30 -Q 30 ${use_bed} -f ${fasta} ${bam_list} | pileupCaller ${caller} ${ssmode} ${transitions_mode} --sampleNames ${sample_names} ${use_snp} -e pileupcaller.${strandedness}
+  samtools mpileup -B --ignore-RG -q ${map_q} -Q ${base_q} ${use_bed} -f ${fasta} ${bam_list} | pileupCaller ${caller} ${ssmode} ${transitions_mode} --sampleNames ${sample_names} ${use_snp} -e pileupcaller.${strandedness}
   """
-}
+}}
 
 process eigenstrat_snp_coverage {
   label 'mc_tiny'

--- a/main.nf
+++ b/main.nf
@@ -2494,7 +2494,7 @@ process genotyping_pileupcaller {
   """
   samtools mpileup -B --ignore-RG -q ${map_q} -Q ${base_q} ${use_bed} -f ${fasta} ${bam_list} | pileupCaller ${caller} ${ssmode} ${transitions_mode} --sampleNames ${sample_names} ${use_snp} -e pileupcaller.${strandedness}
   """
-}}
+}
 
 process eigenstrat_snp_coverage {
   label 'mc_tiny'

--- a/nextflow.config
+++ b/nextflow.config
@@ -174,6 +174,8 @@ params {
   pileupcaller_bedfile = null
   pileupcaller_method = 'randomHaploid'
   pileupcaller_transitions_mode = 'AllSites'
+  pileupcaller_min_map_quality = 30
+  pileupcaller_min_base_quality = 30
   // ANGSD Genotype Likelihoods
   angsd_glmodel = 'samtools'
   angsd_glformat = 'binary'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1185,6 +1185,20 @@
                         "SkipTransitions"
                     ]
                 },
+                "pileupcaller_min_map_quality": {
+                    "type": "integer",
+                    "default": 30,
+                    "description": "The minimum mapping quality to be used for genotyping.",
+                    "fa_icon": "fas fa-filter",
+                    "help_text": "The minimum mapping quality to be used for genotyping. Affects the `samtools pileup` output that is used by pileupcaller. Affects `-q` parameter of samtools mpileup."
+                },
+                "pileupcaller_min_base_quality": {
+                    "type": "integer",
+                    "default": 30,
+                    "description": "The minimum base quality to be used for genotyping.",
+                    "fa_icon": "fas fa-filter",
+                    "help_text": "The minimum base quality to be used for genotyping. Affects the `samtools pileup` output that is used by pileupcaller. Affects `-Q` parameter of samtools mpileup."
+                },
                 "angsd_glmodel": {
                     "type": "string",
                     "default": "samtools",
@@ -1641,7 +1655,7 @@
                 "maltextract_percentidentity": {
                     "type": "number",
                     "description": "Minimum percent identity alignments are required to have to be reported. Recommended to set same as MALT parameter.",
-                    "default": 85,
+                    "default": 85.0,
                     "fa_icon": "fas fa-id-card",
                     "help_text": "Minimum percent identity alignments are required to have to be reported. Higher values allows fewer mismatches between read and reference sequence, but therefore will provide greater confidence in the hit. Lower values allow more mismatches, which can account for damage and divergence of a related strain/species to the reference. Recommended to set same as MALT parameter or higher. Default: `85.0`.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MaltExtract parameter: `--minPI`"
                 },


### PR DESCRIPTION
Small quality of life change. Rather than hardcoding map and base quality filtering of `30` prior to pileupcaller genotyping, the two filters can now be custom set with `--pileupcaller_min_map_quality` and `--pileupcaller_min_base_quality`.


<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
