### PR TITLE
Fix post-ar trimming not being included in downstream analyses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 
-- [#822](https://github.com/nf-core/eager/issues/822) Fixed post-adapterrmoeval trimmied files not being lane-merged and included in downstream analyses
+- [#822](https://github.com/nf-core/eager/issues/822) Fixed post-adapterremoval trimmed files not being lane-merged and included in downstream analyses
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 
+- [#822](https://github.com/nf-core/eager/issues/822) Fixed post-adapterrmoeval trimmied files not being lane-merged and included in downstream analyses
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/main.nf
+++ b/main.nf
@@ -1039,8 +1039,7 @@ if ( params.skip_collapse ){
 
 // Inline barcode removal bypass when not running it 
 if (params.run_post_ar_trimming) {
-    ch_adapterremoval_for_skip_post_ar_trimming
-        .mix( ch_post_ar_trimming_for_lanemerge )
+    ch_post_ar_trimming_for_lanemerge
         .into { ch_inlinebarcoderemoval_for_fastqc_after_clipping; ch_inlinebarcoderemoval_for_lanemerge; } 
 } else {
     ch_adapterremoval_for_skip_post_ar_trimming

--- a/main.nf
+++ b/main.nf
@@ -1040,7 +1040,7 @@ if ( params.skip_collapse ){
 // Inline barcode removal bypass when not running it 
 if (params.run_post_ar_trimming) {
     ch_adapterremoval_for_skip_post_ar_trimming
-        .dump(tag: "inline_removal_bypass")
+        .mix( ch_post_ar_trimming_for_lanemerge )
         .into { ch_inlinebarcoderemoval_for_fastqc_after_clipping; ch_inlinebarcoderemoval_for_lanemerge; } 
 } else {
     ch_adapterremoval_for_skip_post_ar_trimming


### PR DESCRIPTION
I accidently left debugging code rather than mixxing the trimmed files back into the input channel for lane merging 🤦‍♀

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [x] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [x] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).


To cloe #822 