### PR TITLE
Remove deprecated parameters from test profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 
+- [#836](https://github.com/nf-core/eager/issues/836) Remove deprecated parameters from test profiles
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -21,7 +21,6 @@ params {
    bwaalnl = 1024
    
    run_bam_filtering = true
-   bam_discard_unmapped = true
    bam_unmapped_type = 'discard'
    bam_mapping_quality_threshold = 25
      

--- a/conf/test_stresstest_human.config
+++ b/conf/test_stresstest_human.config
@@ -24,7 +24,6 @@ params {
    mtnucratio_header = 'ChrM'
 
    run_bam_filtering = true
-   bam_discard_unmapped = true
    bam_unmapped_type = 'discard'
    bam_mapping_quality_threshold = 30
 


### PR DESCRIPTION
Removes old parameter that leaves ugly message when running test profiles

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
