### PR TITLE
Remove expected `.txt` suffix for snp coverage

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -2549,11 +2549,11 @@ process eigenstrat_snp_coverage {
   /* 
   The following code block can be swapped in once the eigenstratdatabasetools MultiQC module becomes available.
   """
-  eigenstrat_snp_coverage -i pileupcaller.${strandedness} -s ".txt" >${strandedness}_eigenstrat_coverage.txt -j ${strandedness}_eigenstrat_coverage_mqc.json
+  eigenstrat_snp_coverage -i pileupcaller.${strandedness} >${strandedness}_eigenstrat_coverage.txt -j ${strandedness}_eigenstrat_coverage_mqc.json
   """
   */
   """
-  eigenstrat_snp_coverage -i pileupcaller.${strandedness} -s ".txt" >${strandedness}_eigenstrat_coverage.txt
+  eigenstrat_snp_coverage -i pileupcaller.${strandedness} >${strandedness}_eigenstrat_coverage.txt
   parse_snp_cov.py ${strandedness}_eigenstrat_coverage.txt
   """
 }


### PR DESCRIPTION
The most recent version of pileupcaller removes the `.txt` suffix that previous versions added to the genotype files.

`eigenstrat_snp_coverage.py` could not find the input files because it expected these suffixes to be present. With these changes, the script will no longer expect a `.txt` suffix to its input files.
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] `CHANGELOG.md` is updated.
