### PR TITLE
Samtools fastq fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [#828](https://github.com/nf-core/eager/issues/828) Improved error message if required metagenomic screening parameters not set correctly
 - [#836](https://github.com/nf-core/eager/issues/836) Remove deprecated parameters from test profiles
-- [#838](https://github.com/nf-core/eager/issues/836) Fix --snpcapture_bed files not being picked up by Nextflow (thanks to @meganemichel for reporting)
+- [#838](https://github.com/nf-core/eager/issues/836) Fix --snpcapture_bed files not being picked up by Nextflow (❤ to @meganemichel for reporting)
 - [#843](https://github.com/nf-core/eager/issues/843) Re-add direct piping of AdapterRemovalFixPrefix to pigz
 - [#844](https://github.com/nf-core/eager/issues/844) Fixed reference masking prior to pmdtools
 - [#845](https://github.com/nf-core/eager/issues/845) Updates parameter documention to specify `-s` preseq parameter also applies to lc_extrap
 - [#851](https://github.com/nf-core/eager/issues/851) Fixes a file-name clash during additional_library_merge, post-BAM trimming of different UDG treated libraries of a sample
 - Renamed a range of MultiQC general stats table headers to improve clarity, documentation has been updated accordingly
-- [#858](https://github.com/nf-core/eager/pull/858) Corrected tutorials to reflect updated BAM trimming flags (thanks to @marcel-keller for reporting)
+- [#857](https://github.com/nf-core/eager/issues/857) Corrected samtools fastq flag to retain read-pair information when converting off-target BAM files to fastq (❤ to @alexhbnr for reporting)
+- [#858](https://github.com/nf-core/eager/pull/858) Corrected tutorials to reflect updated BAM trimming flags (❤ to @marcel-keller for reporting)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#845](https://github.com/nf-core/eager/issues/845) Updates parameter documention to specify `-s` preseq parameter also applies to lc_extrap
 - [#851](https://github.com/nf-core/eager/issues/851) Fixes a file-name clash during additional_library_merge, post-BAM trimming of different UDG treated libraries of a sample
 - Renamed a range of MultiQC general stats table headers to improve clarity, documentation has been updated accordingly
-- [#857](https://github.com/nf-core/eager/issues/857) Corrected samtools fastq flag to retain read-pair information when converting off-target BAM files to fastq (❤ to @alexhbnr for reporting)
+- [#857](https://github.com/nf-core/eager/issues/857) Corrected samtools fastq flag to _retain_ read-pair information when converting off-target BAM files to fastq in paired-end mapping (❤ to @alexhbnr for reporting)
 - [#858](https://github.com/nf-core/eager/pull/858) Corrected tutorials to reflect updated BAM trimming flags (❤ to @marcel-keller for reporting)
 
 ### `Dependencies`

--- a/main.nf
+++ b/main.nf
@@ -638,7 +638,7 @@ process convertBam {
     script:
     base = "${bam.baseName}"
     """
-    samtools fastq -tn ${bam} | pigz -p ${task.cpus} > ${base}.converted.fastq.gz
+    samtools fastq -t ${bam} | pigz -p ${task.cpus} > ${base}.converted.fastq.gz
     """ 
 }
 
@@ -1683,7 +1683,7 @@ process samtools_filter {
         samtools index ${libraryid}.filtered.bam ${size}
 
         ## FASTQ
-        samtools fastq -tn ${libraryid}.unmapped.bam | pigz -p ${task.cpus - 1} > ${libraryid}.unmapped.fastq.gz
+        samtools fastq -tN ${libraryid}.unmapped.bam | pigz -p ${task.cpus - 1} > ${libraryid}.unmapped.fastq.gz
         rm ${libraryid}.unmapped.bam
         """
     } else if ( "${params.bam_unmapped_type}" == "both" && params.bam_filter_minreadlength == 0 ){
@@ -1693,7 +1693,7 @@ process samtools_filter {
         samtools index ${libraryid}.filtered.bam ${size}
         
         ## FASTQ
-        samtools fastq -tn ${libraryid}.unmapped.bam | pigz -p ${task.cpus -1} > ${libraryid}.unmapped.fastq.gz
+        samtools fastq -tN ${libraryid}.unmapped.bam | pigz -p ${task.cpus -1} > ${libraryid}.unmapped.fastq.gz
         """
     // Unmapped/MAPQ Filtering WITH min-length filtering
     } else if ( "${params.bam_unmapped_type}" == "keep" && params.bam_filter_minreadlength != 0 ) {
@@ -1723,7 +1723,7 @@ process samtools_filter {
         samtools index ${libraryid}.filtered.bam ${size}
 
         ## FASTQ
-        samtools fastq -tn ${libraryid}.unmapped.bam | pigz -p ${task.cpus - 1} > ${libraryid}.unmapped.fastq.gz
+        samtools fastq -tN ${libraryid}.unmapped.bam | pigz -p ${task.cpus - 1} > ${libraryid}.unmapped.fastq.gz
         rm ${libraryid}.unmapped.bam
         """
     } else if ( "${params.bam_unmapped_type}" == "both" && params.bam_filter_minreadlength != 0 ){
@@ -1734,7 +1734,7 @@ process samtools_filter {
         samtools index ${libraryid}.filtered.bam ${size}
         
         ## FASTQ
-        samtools fastq -tn ${libraryid}.unmapped.bam | pigz -p ${task.cpus} > ${libraryid}.unmapped.fastq.gz
+        samtools fastq -tN ${libraryid}.unmapped.bam | pigz -p ${task.cpus} > ${libraryid}.unmapped.fastq.gz
         """
     }
 }


### PR DESCRIPTION
## PR checklist

Replaces `-n` with `-N` to RETAIN read-pair info, not remove it in samtools fastq 🤦‍♀

Fixes #857 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
