### PR TITLE
Define DSL1 explicitly, as Nextflow made DSL2 default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Fixed`
 
 - Fixed some auxiliary files (adapater list, snpcapture/pileupcaller/sexdeterrmine BED files, and pileupCaller SNP file, PMD reference mask) in some cases only be used against one sample (❤ to @meganemichel for reporting, fix by @jfy133)
+- [#882](https://github.com/nf-core/eager/pull/882) Define DSL1 explicitly, as Nextflow made DSL2 default
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [dev]
+
+### `Added`
+
+### `Fixed`
+
+- [#882](https://github.com/nf-core/eager/pull/882) Define DSL1 execution explicitly, as new versions Nextflow made DSL2 default (♥ to & fix from @Lehmann-Fabian)
+
+### `Dependencies`
+
+### `Deprecated`
+
 ## [2.4.4] - 2022-04-08
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Fixed`
 
 - Fixed some auxiliary files (adapater list, snpcapture/pileupcaller/sexdeterrmine BED files, and pileupCaller SNP file, PMD reference mask) in some cases only be used against one sample (❤ to @meganemichel for reporting, fix by @jfy133)
-- [#882](https://github.com/nf-core/eager/pull/882) Define DSL1 explicitly, as Nextflow made DSL2 default
 
 ### `Dependencies`
 

--- a/main.nf
+++ b/main.nf
@@ -10,6 +10,7 @@
  For a list of authors and contributors, see: https://github.com/nf-core/eager/tree/dev#authors-alphabetical
 ------------------------------------------------------------------------------------------------------------
 */
+nextflow.enable.dsl=1
 
 log.info Headers.nf_core(workflow, params.monochrome_logs)
 


### PR DESCRIPTION
Signed-off-by: Lehmann_Fabian <fabian.lehmann@informatik.hu-berlin.de>

Cannot start DSL1 workflows with the newest Nextflow version. So I had to define the DSL version explicitly.

<!--
# nf-core/eager pull request

Many thanks for contributing to nf-core/eager!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
