### PR TITLE
DSL2: subworkflow metagenomics profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - "--preprocessing_tool adapterremoval --preprocessing_adapterlist 'https://github.com/nf-core/test-datasets/raw/modules/data/delete_me/adapterremoval/adapterremoval_adapterlist.txt' --sequencing_qc_tool falco"
           - "--mapping_tool bwamem"
           - "--skip_preprocessing"
+          - "--run_mtnucratio --mitochondrion_header 'NC_007596.2'"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v3

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -18,7 +18,7 @@
 
 - [Falco](https://doi.org/10.12688%2Ff1000research.21142.2)
 
-  > de Sena Brandine, G., Smith, A.D. (2019) Falco: high-speed FastQC emulation for quality control of sequencing data. F1000Res., 8, 1874. doi: [10.12688%2Ff1000research.21142.2](https://doi.org/10.12688%2Ff1000research.21142.2)
+  > de Sena Brandine, G., Smith, A.D. (2019). Falco: high-speed FastQC emulation for quality control of sequencing data. F1000Res., 8, 1874. doi: [10.12688%2Ff1000research.21142.2](https://doi.org/10.12688%2Ff1000research.21142.2)
 
 - [fastp](https://doi.org/10.1093/bioinformatics/bty560)
 
@@ -55,6 +55,22 @@
 - [PreSeq](https://doi.org/10.1038/nmeth.2375)
 
   > Daley, T., & Smith, A. D. (2013). Predicting the molecular complexity of sequencing libraries. Nature Methods, 10(4), 325–327. doi: [10.1038/nmeth.2375](https://doi.org/10.1038/nmeth.2375)
+
+- [MALT](https://www.nature.com/articles/s41559-017-0446-6)
+
+  > Vågene, Å.J., Herbig, A., Campana, M.G., Nelly, M., García, R., Warinner, C., Sabin, S., Spyrou, M.A., Valtueña, A.A., Huson, D., Tuross, N., Bos, K.I. & Krause, J. (2018). Salmonella enterica genomes from victims of a major sixteenth-century epidemic in Mexico. Nat Ecol Evol 2, 520–528. doi: [10.1038/s41559-017-0446-6](https://doi.org/10.1038/s41559-017-0446-6)
+
+- [Kraken2](https://doi.org/10.1186/s13059-019-1891-0)
+
+  > Wood, Derrick E., Jennifer Lu, and Ben Langmead. 2019. Improved Metagenomic Analysis with Kraken 2. Genome Biology 20 (1): 257. doi: 10.1186/s13059-019-1891-0.
+
+- [KrakenUniq](https://doi.org/10.1186/s13059-018-1568-0)
+
+  > Breitwieser, Florian P., Daniel N. Baker, and Steven L. Salzberg. 2018. KrakenUniq: confident and fast metagenomics classification using unique k-mer counts. Genome Biology 19 (1): 198. doi: 10.1186/s13059-018-1568-0
+
+- [MetaPhlAn3](https://doi.org/10.7554/eLife.65088)
+
+  > Beghini, Francesco, Lauren J McIver, Aitor Blanco-Míguez, Leonard Dubois, Francesco Asnicar, Sagun Maharjan, Ana Mailyan, et al. 2021. “Integrating Taxonomic, Functional, and Strain-Level Profiling of Diverse Microbial Communities with BioBakery 3.” Edited by Peter Turnbaugh, Eduardo Franco, and C Titus Brown. ELife 10 (May): e65088. doi: 10.7554/eLife.65088
 
 ## Software packaging/containerisation tools
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -44,6 +44,14 @@
 
   > Peltzer, A., Jäger, G., Herbig, A., Seitz, A., Kniep, C., Krause, J., & Nieselt, K. (2016). EAGER: efficient ancient genome reconstruction. Genome Biology, 17(1), 1–14. doi: [10.1186/s13059-016-0918-z](https://doi.org/10.1186/s13059-016-0918-z)
 
+- [prinseqplusplus](https://doi.org/10.7287/peerj.preprints.27553v1)
+
+  > Cantu VA, Sadural J, Edwards R. 2019. PRINSEQ++, a multi-threaded tool for fast and efficient quality control and preprocessing of sequencing datasets. PeerJ Preprints 7:e27553v1. doi: [10.7287/peerj.preprints.27553v1](https://doi.org/10.7287/peerj.preprints.27553v1)
+
+- [bbduk](https://doi.org/10.1371/journal.pone.0185056)
+
+  > Bushnell B, Rood J, Singer E (2017) BBMerge – Accurate paired shotgun read merging via overlap. PLOS ONE 12(10): e0185056. [https://doi.org/10.1371/journal.pone.0185056](https://doi.org/10.1371/journal.pone.0185056)
+
 - [PreSeq](https://doi.org/10.1038/nmeth.2375)
 
   > Daley, T., & Smith, A. D. (2013). Predicting the molecular complexity of sequencing libraries. Nature Methods, 10(4), 325–327. doi: [10.1038/nmeth.2375](https://doi.org/10.1038/nmeth.2375)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Additional functionality contained by the pipeline currently includes:
 
 #### Metagenomic Screening
 
-- Low-sequenced complexity filtering (`BBduk`)
+- Low-sequenced complexity filtering (`BBduk` or `PRINSEQ++`)
 - Taxonomic binner with alignment (`MALT`)
 - Taxonomic binner without alignment (`Kraken2`)
 - aDNA characteristic screening of taxonomically binned data from MALT (`MaltExtract`)
@@ -136,6 +136,7 @@ We thank the following people for their extensive assistance in the development 
 - [Fabian Lehmann](https://github.com/Lehmann-Fabian)
 - [He Yu](https://github.com/paulayu)
 - [Hester van Schalkwyk](https://github.com/hesterjvs)
+- [Ian Light-Máka](https://github.com/ilight1542)
 - [Ido Bar](https://github.com/IdoBar)
 - [Irina Velsko](https://github.com/ivelsko)
 - [Işın Altınkaya](https://github.com/isinaltinkaya)
@@ -148,6 +149,7 @@ We thank the following people for their extensive assistance in the development 
 - [Mahesh Binzer-Panchal](https://github.com/mahesh-panchal)
 - [Marcel Keller](https://github.com/marcel-keller)
 - [Megan Michel](https://github.com/meganemichel)
+- [Merlin Szymanski](https://github.com/merszym)
 - [Pierre Lindenbaum](https://github.com/lindenb)
 - [Pontus Skoglund](https://github.com/pontussk)
 - [Raphael Eisenhofer](https://github.com/EisenRa)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -357,7 +357,7 @@ process {
             enabled: params.bamfiltering_generatemappedfastq
         ]
         ext.args = [
-            params.metagenomicscreening_input == 'all' ? '' : '-F 4',
+            params.metagenomics_input == 'all' ? '' : '-F 4',
         ].join(' ').trim()
         ext.prefix = { "${meta.id}_${meta.library_id}_mapped" }
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -448,6 +448,33 @@ process {
         ]
     }
 
+    withName: PRINSEQPLUSPLUS {
+        ext.args =  [
+                params.metagenomics_prinseq_mode == 'dust' ? "-lc_dust=${params.metagenomics_prinseq_dustscore}" : "-lc_entropy=${params.metagenomics_complexity_entropy}",
+                "-trim_qual_left=0 -trim_qual_left=0 -trim_qual_window=0 -trim_qual_step=0",
+            ].join(' ').trim()
+        ext.prefix = { "${meta.id}_${meta.library_id}_complexity" }
+        publishDir = [
+            [
+                path: { "${params.outdir}/metagenomic_complexity_filter/" },
+                mode: params.publish_dir_mode,
+                pattern: '*{_good_out.fastq.gz,_good_out_R1.fastq.gz,_good_out_R2.fastq.gz,log}',
+                enabled: params.metagenomics_complexity_savefastq
+            ]
+        ]
+    }
+
+    withName: ".*BBMAP_BBDUK" {
+        ext.prefix = { "${meta.id}_${meta.library_id}_complexity" }
+        ext.args = { "entropymask=f entropy=${params.metagenomics_complexity_entropy}" }
+        publishDir = [
+            path: { "${params.outdir}/metagenomic_complexity_filter/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{fastq.gz,log}',
+            enabled: params.metagenomics_complexity_savefastq
+        ]
+    }
+
     withName: MTNUCRATIO {
         publishDir = [
             enabled: false

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -482,15 +482,15 @@ process {
     }
     withName: MALT_RUN {
         ext.args = [
-            "-m ${params.metagenomics_profiling_malt_mode}",
-            "-at ${params.metagenomics_profiling_malt_alignment_mode}",
-            "-top ${params.metagenomics_profiling_malt_top_percent}",
-            "-id ${params.metagenomics_profiling_malt_min_percent_identity}",
-            "-mq ${params.metagenomics_profiling_malt_max_queries}",
-            "--memoryMode ${params.metagenomics_profiling_malt_memory_mode}",
-            params.metagenomics_profiling_malt_min_support_mode == "percent" ? "-supp ${params.metagenomics_profiling_malt_min_support_percent}" : "-sup ${params.metagenomics_profiling_malt_min_support_reads}",
-            params.metagenomics_profiling_malt_sam_output ? "-a . -f SAM" : "",
-            params.metagenomics_profiling_malt_save_reads ? "--alignments ./ -za false" : ""
+            "-m ${params.metagenomics_malt_mode}",
+            "-at ${params.metagenomics_malt_alignment_mode}",
+            "-top ${params.metagenomics_malt_top_percent}",
+            "-id ${params.metagenomics_malt_min_percent_identity}",
+            "-mq ${params.metagenomics_malt_max_queries}",
+            "--memoryMode ${params.metagenomics_malt_memory_mode}",
+            params.metagenomics_malt_min_support_mode == "percent" ? "-supp ${params.metagenomics_malt_min_support_percent}" : "-sup ${params.metagenomics_malt_min_support_reads}",
+            params.metagenomics_malt_sam_output ? "-a . -f SAM" : "",
+            params.metagenomics_malt_save_reads ? "--alignments ./ -za false" : ""
         ].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/metagenomics_screening/profiling/malt/" },
@@ -502,7 +502,7 @@ process {
     withName: KRAKEN2_KRAKEN2 {
         ext.prefix = params.perform_runmerging ? "${meta.id}.kraken2" : "${meta.id}_${meta.run_accession}.kraken2"
         ext.args = [
-            params.metagenomics_profiling_kraken2_save_minimizers ? "-report-minimizer-data" : ""
+            params.metagenomics_kraken2_save_minimizers ? "-report-minimizer-data" : ""
         ].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/metagenomics_screening/profiling/kraken2/" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -447,4 +447,10 @@ process {
             pattern: '*.flagstat'
         ]
     }
+
+    withName: MTNUCRATIO {
+        publishDir = [
+            enabled: false
+        ]
+    }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -480,6 +480,7 @@ process {
             enabled: false
         ]
     }
+
     withName: MALT_RUN {
         ext.args = [
             "-m ${params.metagenomics_malt_mode}",
@@ -527,5 +528,4 @@ process {
             pattern: '*.{biom,txt}'
         ]
     }
-
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -480,4 +480,52 @@ process {
             enabled: false
         ]
     }
+    withName: MALT_RUN {
+        ext.args = [
+            "-m ${params.metagenomics_profiling_malt_mode}",
+            "-at ${params.metagenomics_profiling_malt_alignment_mode}",
+            "-top ${params.metagenomics_profiling_malt_top_percent}",
+            "-id ${params.metagenomics_profiling_malt_min_percent_identity}",
+            "-mq ${params.metagenomics_profiling_malt_max_queries}",
+            "--memoryMode ${params.metagenomics_profiling_malt_memory_mode}",
+            params.metagenomics_profiling_malt_min_support_mode == "percent" ? "-supp ${params.metagenomics_profiling_malt_min_support_percent}" : "-sup ${params.metagenomics_profiling_malt_min_support_reads}",
+            params.metagenomics_profiling_malt_sam_output ? "-a . -f SAM" : "",
+            params.metagenomics_profiling_malt_save_reads ? "--alignments ./ -za false" : ""
+        ].join(' ').trim()
+        publishDir = [
+            path: { "${params.outdir}/metagenomics_screening/profiling/malt/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{rma6,log,sam}'
+        ]
+    }
+
+    withName: KRAKEN2_KRAKEN2 {
+        ext.prefix = params.perform_runmerging ? "${meta.id}.kraken2" : "${meta.id}_${meta.run_accession}.kraken2"
+        ext.args = [
+            params.metagenomics_profiling_kraken2_save_minimizers ? "-report-minimizer-data" : ""
+        ].join(' ').trim()
+        publishDir = [
+            path: { "${params.outdir}/metagenomics_screening/profiling/kraken2/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{txt,fastq.gz}'
+        ]
+    }
+
+    withName: KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
+        publishDir = [
+            path: { "${params.outdir}/metagenomics_screening/profiling/krakenuniq/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{txt,fastq.gz}'
+        ]
+    }
+
+    withName: METAPHLAN3_METAPHLAN3 {
+        ext.prefix = params.perform_runmerging ? { "${meta.id}.metaphlan3" } : { "${meta.id}_${meta.run_accession}.metaphlan3" }
+        publishDir = [
+            path: { "${params.outdir}/metagenomics_screening/profiling/metaphlan3/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{biom,txt}'
+        ]
+    }
+
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -33,7 +33,7 @@ params {
     bamfiltering_mappingquality           = 37
 
     // Metagenomic screening
-    run_metagenomics_screening             = false
+    run_metagenomics             = false
 
 
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -33,7 +33,7 @@ params {
     bamfiltering_mappingquality           = 37
 
     // Metagenomic screening
-    run_metagenomicscreening             = false
+    run_metagenomics_screening             = false
 
 
 }

--- a/docs/development/manual_tests.md
+++ b/docs/development/manual_tests.md
@@ -208,8 +208,8 @@ All possible parameters
     bamfiltering_savefilteredbam          = false // can include unmapped reads if --bamfiltering_retainunmappedgenomicbam specified
 
     // Metagenomic Screening
-    run_metagenomicscreening   = false
-    metagenomicscreening_input = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
+    run_metagenomics_screening   = false
+    metagenomics_input = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
 ```
 
 Tests
@@ -270,45 +270,45 @@ nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log f
 
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with unmapped reads to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match approx unmmaped reads in results/mapping/*.flagstat
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomicscreening -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening -dump-channels
 
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with mapped only reads going to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should match approx mmaped reads in results/mapping/*.flagstat
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomicscreening --metagenomicscreening_input 'mapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening --metagenomics_input 'mapped' -dump-channels
 
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with all reads going to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should match total reads in results/mapping/*.flagstat
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomicscreening --metagenomicscreening_input 'all' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening --metagenomics_input 'all' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with unmapped reads to metagenomics
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat. Note: No filtered flagstat expected!
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomicscreening --metagenomicscreening_input 'unmapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with unmapped reads to metagenomics and save unmapped FASTQ
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat; and unmapped other fASTQ in bam_filtering directoryt. Note: No filtered flagstat expected!
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomicscreening --metagenomicscreening_input 'unmapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with mapped only reads going to metagenomics
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should be roughly matching mappd reads as calculated from results/mapping/*.flagstatt. Note: No filtered flagstat expected!
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomicscreening --metagenomicscreening_input 'mapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'mapped' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with all reads going to metagenomics
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should be roughly matching total reads as calculated from results/mapping/*.flagstatt. Note: No filtered flagstat expected!
 ## Some reads lost, not 100% why command looks OK... but not just unmapped as more than that
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomicscreening --metagenomicscreening_input 'all' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'all' -dump-channels
 
 ## Check BAM filtering ONLY length filtering, with metagenomics screening, with unmapped reads to metagenomics and save unmapped FASTQ
 ## Metagenomics with length only
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min >= 50), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat; and unmapped other fASTQ in bam_filtering directoryt.
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomicscreening --metagenomicscreening_input 'unmapped' -dump-channels --bamfiltering_minreadlength 50
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels --bamfiltering_minreadlength 50
 
 ## Check BAM filtering ONLY length filtering, with metagenomics screening, with unmapped reads to metagenomics and save unmapped FASTQ
 ## Metagenomics with length only
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is not different  and  RL reads min <= 50), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat; and unmapped other fASTQ in bam_filtering directoryt.
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomicscreening --metagenomicscreening_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37
 
 ## Check what happens when we do paired-end merging and sending reads to metagenomics...
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomicscreening --metagenomicscreening_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37 --preprocessing_skippairmerging
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37 --preprocessing_skippairmerging
 ```
 
 ## Deduplication

--- a/docs/development/manual_tests.md
+++ b/docs/development/manual_tests.md
@@ -271,6 +271,7 @@ nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log f
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with unmapped reads to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match approx unmmaped reads in results/mapping/*.flagstat
 nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening -dump-channels
 
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with mapped only reads going to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should match approx mmaped reads in results/mapping/*.flagstat

--- a/docs/development/manual_tests.md
+++ b/docs/development/manual_tests.md
@@ -208,7 +208,7 @@ All possible parameters
     bamfiltering_savefilteredbam          = false // can include unmapped reads if --bamfiltering_retainunmappedgenomicbam specified
 
     // Metagenomic Screening
-    run_metagenomics_screening   = false
+    run_metagenomics   = false
     metagenomics_input = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
 ```
 
@@ -270,46 +270,46 @@ nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log f
 
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with unmapped reads to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match approx unmmaped reads in results/mapping/*.flagstat
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening -dump-channels
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics -dump-channels
 
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with mapped only reads going to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should match approx mmaped reads in results/mapping/*.flagstat
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening --metagenomics_input 'mapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics --metagenomics_input 'mapped' -dump-channels
 
 ## Check BAM filtering (mapped only/length/quality on genomic bam) with metagenomics screening, with all reads going to metagenomics
 # Expect: filtered BAM (samtools stats | grep SN total/mapped same), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should match total reads in results/mapping/*.flagstat
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics_screening --metagenomics_input 'all' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --bamfiltering_minreadlength 50 --bamfiltering_mappingquality 37 --run_metagenomics --metagenomics_input 'all' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with unmapped reads to metagenomics
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat. Note: No filtered flagstat expected!
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics --metagenomics_input 'unmapped' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with unmapped reads to metagenomics and save unmapped FASTQ
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat; and unmapped other fASTQ in bam_filtering directoryt. Note: No filtered flagstat expected!
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics --metagenomics_input 'unmapped' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with mapped only reads going to metagenomics
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should be roughly matching mappd reads as calculated from results/mapping/*.flagstatt. Note: No filtered flagstat expected!
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'mapped' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics --metagenomics_input 'mapped' -dump-channels
 
 ## Check BAM filtering NO LENGTH/QAULITY with metagenomics screening, with all reads going to metagenomics
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min <50), and a dump() on the ch_bam_for_metagenomics channel should report mapped_other. Nr. of reads in dumped FASTQ should be roughly matching total reads as calculated from results/mapping/*.flagstatt. Note: No filtered flagstat expected!
 ## Some reads lost, not 100% why command looks OK... but not just unmapped as more than that
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'all' -dump-channels
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics --metagenomics_input 'all' -dump-channels
 
 ## Check BAM filtering ONLY length filtering, with metagenomics screening, with unmapped reads to metagenomics and save unmapped FASTQ
 ## Metagenomics with length only
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is different  and  RL reads min >= 50), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat; and unmapped other fASTQ in bam_filtering directoryt.
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels --bamfiltering_minreadlength 50
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics --metagenomics_input 'unmapped' -dump-channels --bamfiltering_minreadlength 50
 
 ## Check BAM filtering ONLY length filtering, with metagenomics screening, with unmapped reads to metagenomics and save unmapped FASTQ
 ## Metagenomics with length only
 # Expect: filtered BAM (samtools stats SN quality average < 36.7 or view -q 0 vs. -q 37 is not different  and  RL reads min <= 50), and a dump() on the ch_bam_for_metagenomics channel should report unmapped_other. Nr. of reads in dumped FASTQ should match unmapped reads as calculated from results/mapping/*.flagstat; and unmapped other fASTQ in bam_filtering directoryt.
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics --metagenomics_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37
 
 ## Check what happens when we do paired-end merging and sending reads to metagenomics...
-nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics_screening --metagenomics_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37 --preprocessing_skippairmerging
+nextflow run ../main.nf -profile test,singularity --outdir ./results -ansi-log false --input data/samplesheet.tsv --fasta data/reference/Mammoth_MT_Krause.fasta --run_bamfiltering --bamfiltering_savefilteredbams --run_metagenomics --metagenomics_input 'unmapped' -dump-channels --bamfiltering_mappingquality 37 --preprocessing_skippairmerging
 ```
 
 ## Deduplication

--- a/docs/output.md
+++ b/docs/output.md
@@ -171,6 +171,46 @@ Please be aware, that intermediate length and mapping quality filtered genomic B
 
 You may also recieve the files above if metagenomic screening is turned on.
 
+### Metagenomics Screening
+
+#### Bbduk
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `metagenomic_complexity_filter/`
+
+  - `*_complexity.fastq.gz`: FASTQ file containing the complexity filtered reads
+  - `*.log`: LOG file containing filter stats
+  </details>
+
+The entropy filter of [BBDuk](https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/bbduk-guide/) is used to remove reads from the fastq-files for metagenomics screening that don't pass the `--metagenomics_complexity_entropy` threshold. When ommiting the flag, a default value of 0.3 is applied. To cite the docs:
+
+> A homopolymer such as AAAAAAAAAAAAAA would have entropy of zero; completely random sequence would have entropy approaching 1.
+
+Using complexity-filtered fastq-files as input for metagenomic classifiers can reduce the number of false positive classifications, resulting in more precise taxonomic assignments of the sample through removal of reads that can align equally well to multiple reference genomes. Save the complexity-filtered fastq-files to the output directory to perform additional downstream analyses, such as testing multiple metagenomic profilers (see the [nf-core/taxprofiler](https://github.com/nf-core/taxprofiler) pipeline).
+
+**Note:** To save output files, set the `--metagenomics_complexity_savefastq` flag
+
+#### PRINSEQ++
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `metagenomic_complexity_filter/`
+
+  - `*_complexity_good_out.fastq.gz`: FASTQ file containing the complexity filtered reads
+  - `*_complexity.log`: LOG file containing filter stats
+  </details>
+
+  [PRINSEQ++](https://github.com/Adrian-Cantu/PRINSEQ-plus-plus#readme) is an alternative to BBDuk for filtering the fastq files before metagenomics classification. From PRINSEQ++ we implemented filtering by the `dust` algorithm or by `entropy`, as explained above in the BBDuk section.
+
+  Using complexity-filtered fastq-files as input for metagenomic classifiers can reduce the number of false positive classifications, resulting in more precise taxonomic assignments of the sample. Save the complexity-filtered fastq-files to the output directory to perform additional downstream analyses, such as testing multiple metagenomic profilers (see the [nf-core/taxprofiler](https://github.com/nf-core/taxprofiler) pipeline).
+
+  The saved files are the _good_ files, passing the `dust` or `entropy` filter treshold specified. The logs contain information about the amount of reads filtered.
+
+  **Note:** To save output files, set the `--metagenomics_complexity_savefastq` flag
+
 ### Deduplication
 
 <details markdown="1">

--- a/modules.json
+++ b/modules.json
@@ -107,6 +107,31 @@
                     },
                     "mtnucratio": {
                         "branch": "master",
+                        "git_sha": "7c695e0147df1157413e06246d9b0094617d3e6b",
+                        "installed_by": ["modules"]
+                    },
+                    "kraken2/kraken2": {
+                        "branch": "master",
+                        "git_sha": "7c695e0147df1157413e06246d9b0094617d3e6b",
+                        "installed_by": ["modules"]
+                    },
+                    "krakenuniq/preloadedkrakenuniq": {
+                        "branch": "master",
+                        "git_sha": "a6eb17f65b3ee5761c25c075a6166c9f76733cee",
+                        "installed_by": ["modules"]
+                    },
+                    "malt/run": {
+                        "branch": "master",
+                        "git_sha": "75027bf77472b1f4fd2cdd7e46f83119dfb0f2c6",
+                        "installed_by": ["modules"]
+                    },
+                    "maltextract": {
+                        "branch": "master",
+                        "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
+                        "installed_by": ["modules"]
+                    },
+                    "metaphlan3/metaphlan3": {
+                        "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },

--- a/modules.json
+++ b/modules.json
@@ -10,6 +10,11 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
+                    "bbmap/bbduk": {
+                        "branch": "master",
+                        "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
+                        "installed_by": ["modules"]
+                    },
                     "bowtie2/build": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
@@ -91,6 +96,11 @@
                         "installed_by": ["modules"]
                     },
                     "picard/markduplicates": {
+                        "branch": "master",
+                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "installed_by": ["modules"]
+                    },
+                    "prinseqplusplus": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]

--- a/modules.json
+++ b/modules.json
@@ -80,6 +80,31 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
+                    "kraken2/kraken2": {
+                        "branch": "master",
+                        "git_sha": "7c695e0147df1157413e06246d9b0094617d3e6b",
+                        "installed_by": ["modules"]
+                    },
+                    "krakenuniq/preloadedkrakenuniq": {
+                        "branch": "master",
+                        "git_sha": "a6eb17f65b3ee5761c25c075a6166c9f76733cee",
+                        "installed_by": ["modules"]
+                    },
+                    "malt/run": {
+                        "branch": "master",
+                        "git_sha": "75027bf77472b1f4fd2cdd7e46f83119dfb0f2c6",
+                        "installed_by": ["modules"]
+                    },
+                    "maltextract": {
+                        "branch": "master",
+                        "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
+                        "installed_by": ["modules"]
+                    },
+                    "metaphlan3/metaphlan3": {
+                        "branch": "master",
+                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "installed_by": ["modules"]
+                    },
                     "mtnucratio": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",

--- a/modules.json
+++ b/modules.json
@@ -75,6 +75,11 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
+                    "mtnucratio": {
+                        "branch": "master",
+                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "installed_by": ["modules"]
+                    },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "ee80d14721e76e2e079103b8dcd5d57129e584ba",

--- a/modules.json
+++ b/modules.json
@@ -125,11 +125,6 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
-                    "prinseqplusplus": {
-                        "branch": "master",
-                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
-                    },
                     "preseq/ccurve": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
@@ -138,6 +133,11 @@
                     "preseq/lcextrap": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
+                        "installed_by": ["modules"]
+                    },
+                    "prinseqplusplus": {
+                        "branch": "master",
+                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
                     "samtools/faidx": {

--- a/modules/nf-core/bbmap/bbduk/main.nf
+++ b/modules/nf-core/bbmap/bbduk/main.nf
@@ -1,0 +1,43 @@
+process BBMAP_BBDUK {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "bioconda::bbmap=39.01"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bbmap:39.01--h5c4e2a8_0':
+        'quay.io/biocontainers/bbmap:39.01--h5c4e2a8_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path contaminants
+
+    output:
+    tuple val(meta), path('*.fastq.gz'), emit: reads
+    tuple val(meta), path('*.log')     , emit: log
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def raw      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
+    def trimmed  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"
+    def contaminants_fa = contaminants ? "ref=$contaminants" : ''
+    """
+    maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')
+    bbduk.sh \\
+        -Xmx\$maxmem \\
+        $raw \\
+        $trimmed \\
+        threads=$task.cpus \\
+        $args \\
+        $contaminants_fa \\
+        &> ${prefix}.bbduk.log
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bbmap/bbduk/meta.yml
+++ b/modules/nf-core/bbmap/bbduk/meta.yml
@@ -1,0 +1,52 @@
+name: bbmap_bbduk
+description: Adapter and quality trimming of sequencing reads
+keywords:
+  - trimming
+  - adapter trimming
+  - quality trimming
+  - fastq
+tools:
+  - bbmap:
+      description: BBMap is a short read aligner, as well as various other bioinformatic tools.
+      homepage: https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/
+      documentation: https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/
+
+      licence: ["UC-LBL license (see package)"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - contaminants:
+      type: file
+      description: |
+        Reference files containing adapter and/or contaminant sequences for sequence kmer matching
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: The trimmed/modified fastq reads
+      pattern: "*fastq.gz"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - log:
+      type: file
+      description: Bbduk log file
+      pattern: "*bbduk.log"
+
+authors:
+  - "@MGordon09"

--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -1,0 +1,58 @@
+process KRAKEN2_KRAKEN2 {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "bioconda::kraken2=2.1.2 conda-forge::pigz=2.6"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-5799ab18b5fc681e75923b2450abaa969907ec98:87fc08d11968d081f3e8a37131c1f1f6715b6542-0' :
+        'quay.io/biocontainers/mulled-v2-5799ab18b5fc681e75923b2450abaa969907ec98:87fc08d11968d081f3e8a37131c1f1f6715b6542-0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path  db
+    val save_output_fastqs
+    val save_reads_assignment
+
+    output:
+    tuple val(meta), path('*.classified{.,_}*')     , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
+    tuple val(meta), path('*classifiedreads.txt')   , optional:true, emit: classified_reads_assignment
+    tuple val(meta), path('*report.txt')                           , emit: report
+    path "versions.yml"                                            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def paired       = meta.single_end ? "" : "--paired"
+    def classified   = meta.single_end ? "${prefix}.classified.fastq"   : "${prefix}.classified#.fastq"
+    def unclassified = meta.single_end ? "${prefix}.unclassified.fastq" : "${prefix}.unclassified#.fastq"
+    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ""
+    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ""
+    def readclassification_option = save_reads_assignment ? "--output ${prefix}.kraken2.classifiedreads.txt" : "--output /dev/null"
+    def compress_reads_command = save_output_fastqs ? "pigz -p $task.cpus *.fastq" : ""
+
+    """
+    kraken2 \\
+        --db $db \\
+        --threads $task.cpus \\
+        --report ${prefix}.kraken2.report.txt \\
+        --gzip-compressed \\
+        $unclassified_option \\
+        $classified_option \\
+        $readclassification_option \\
+        $paired \\
+        $args \\
+        $reads
+
+    $compress_reads_command
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/kraken2/kraken2/meta.yml
+++ b/modules/nf-core/kraken2/kraken2/meta.yml
@@ -1,0 +1,75 @@
+name: kraken2_kraken2
+description: Classifies metagenomic sequence data
+keywords:
+  - classify
+  - metagenomics
+  - fastq
+  - db
+tools:
+  - kraken2:
+      description: |
+        Kraken2 is a taxonomic sequence classifier that assigns taxonomic labels to sequence reads
+      homepage: https://ccb.jhu.edu/software/kraken2/
+      documentation: https://github.com/DerrickWood/kraken2/wiki/Manual
+      doi: 10.1186/s13059-019-1891-0
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - db:
+      type: directory
+      description: Kraken2 database
+  - save_output_fastqs:
+      type: boolean
+      description: |
+        If true, optional commands are added to save classified and unclassified reads
+        as fastq files
+  - save_reads_assignment:
+      type: boolean
+      description: |
+        If true, an optional command is added to save a file reporting the taxonomic
+        classification of each input read
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - classified_reads_fastq:
+      type: file
+      description: |
+        Reads classified as belonging to any of the taxa
+        on the Kraken2 database.
+      pattern: "*{fastq.gz}"
+  - unclassified_reads_fastq:
+      type: file
+      description: |
+        Reads not classified to any of the taxa
+        on the Kraken2 database.
+      pattern: "*{fastq.gz}"
+  - classified_reads_assignment:
+      type: file
+      description: |
+        Kraken2 output file indicating the taxonomic assignment of
+        each input read
+  - report:
+      type: file
+      description: |
+        Kraken2 report containing stats about classified
+        and not classifed reads.
+      pattern: "*.{report.txt}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -1,0 +1,224 @@
+process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "bioconda::krakenuniq=1.0.2"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/krakenuniq:1.0.2--pl5321h19e8d03_0':
+        'quay.io/biocontainers/krakenuniq:1.0.2--pl5321h19e8d03_0' }"
+
+    input:
+    tuple val(meta), path(fastqs)
+    path  db
+    val ram_chunk_size
+    val save_output_fastqs
+    val report_file
+    val save_output
+
+    output:
+    tuple val(meta), path('*.classified{.,_}*')     , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
+    tuple val(meta), path('*classified.txt')        , optional:true, emit: classified_assignment
+    tuple val(meta), path('*report.txt')                           , emit: report
+
+    path "versions.yml"                                            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args ?: ''
+
+    def classified   = meta.single_end ? '"\${PREFIX}.classified.fastq"'   : '"\${PREFIX}.classified#.fastq"'
+    def unclassified = meta.single_end ? '"\${PREFIX}.unclassified.fastq"' : '"\${PREFIX}.unclassified#.fastq"'
+    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ''
+    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ''
+    def output_option = save_output ? '--output "\${PREFIX}.krakenuniq.classified.txt"' : ''
+    def report = report_file ? '--report-file "\${PREFIX}.krakenuniq.report.txt"' : ''
+    def compress_reads_command = save_output_fastqs ? 'gzip --no-name *.fastq' : ''
+    if (meta.single_end) {
+        """
+        krakenuniq \\
+            --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
+            --threads $task.cpus \\
+            $args
+
+        strip_suffix() {
+            local result=\$1
+            # Strip any file extensions.
+            echo "\${result%%.*}"
+        }
+
+        printf "%s\\n" ${fastqs} | while read FASTQ; do \\
+            PREFIX="\$(strip_suffix "\${FASTQ}")"
+
+            krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                $args2 \\
+                "\${FASTQ}"
+        done
+
+        $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    } else {
+        """
+        krakenuniq \\
+            --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
+            --threads $task.cpus \\
+            $args
+
+        strip_suffix() {
+            local result
+            read result
+            # Strip any trailing dot or underscore.
+            result="\${result%_}"
+            echo "\${result%.}"
+        }
+
+        printf "%s %s\\n" ${fastqs} | while read FASTQ; do \\
+            read -r -a FASTQ <<< "\${FASTQ}"
+            PREFIX="\$(printf "%s\\n" "\${FASTQ[@]}" |  sed -e 'N;s/^\\(.*\\).*\\n\\1.*\$/\\1\\n\\1/;D' | strip_suffix)"
+
+            krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                --paired \\
+                $args2 \\
+                "\${FASTQ[@]}"
+        done
+
+        $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    }
+
+    stub:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args ?: ''
+
+    def classified   = meta.single_end ? '"\${PREFIX}.classified.fastq"'   : '"\${PREFIX}.classified#.fastq"'
+    def unclassified = meta.single_end ? '"\${PREFIX}.unclassified.fastq"' : '"\${PREFIX}.unclassified#.fastq"'
+    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ''
+    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ''
+    def output_option = save_output ? '--output "\${PREFIX}.krakenuniq.classified.txt"' : ''
+    def report = report_file ? '--report-file "\${PREFIX}.krakenuniq.report.txt"' : ''
+    def compress_reads_command = save_output_fastqs ? 'gzip --no-name *.fastq' : ''
+    if (meta.single_end) {
+        """
+        echo krakenuniq \\
+            --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
+            --threads $task.cpus \\
+            $args
+
+        strip_suffix() {
+            local result=\$1
+            # Strip any file extensions.
+            echo "\${result%%.*}"
+        }
+
+        printf "%s\\n" ${fastqs} | while read FASTQ; do \\
+            echo "\${FASTQ}"
+            PREFIX="\$(strip_suffix "\${FASTQ}")"
+            echo "\${PREFIX}"
+
+            echo krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                $args2 \\
+                "\${FASTQ}"
+
+            touch "\${PREFIX}.classified.fastq.gz"
+            touch "\${PREFIX}.krakenuniq.classified.txt"
+            touch "\${PREFIX}.krakenuniq.report.txt"
+            touch "\${PREFIX}.unclassified.fastq.gz"
+        done
+
+        echo $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    } else {
+        """
+        echo krakenuniq \\
+            --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
+            --threads $task.cpus \\
+            $args
+
+        strip_suffix() {
+            local result
+            read result
+            # Strip any trailing dot or underscore.
+            result="\${result%_}"
+            echo "\${result%.}"
+        }
+
+        printf "%s %s\\n" ${fastqs} | while read FASTQ; do \\
+            read -r -a FASTQ <<< "\${FASTQ}"
+            echo "\${FASTQ[@]}"
+            PREFIX="\$(printf "%s\\n" "\${FASTQ[@]}" |  sed -e 'N;s/^\\(.*\\).*\\n\\1.*\$/\\1\\n\\1/;D' | strip_suffix)"
+            echo "\${PREFIX}"
+
+            echo krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                --paired \\
+                $args2 \\
+                "\${FASTQ[@]}"
+
+            touch "\${PREFIX}.classified_1.fastq.gz" "\${PREFIX}.classified_2.fastq.gz"
+            touch "\${PREFIX}.krakenuniq.classified.txt"
+            touch "\${PREFIX}.krakenuniq.report.txt"
+            touch "\${PREFIX}.unclassified_1.fastq.gz" "\${PREFIX}.unclassified_2.fastq.gz"
+        done
+
+        echo $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    }
+}

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/meta.yml
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/meta.yml
@@ -1,0 +1,78 @@
+name: "krakenuniq_preloadedkrakenuniq"
+description: Classifies metagenomic sequence data using unique k-mer counts
+keywords:
+  - classify
+  - metagenomics
+  - kmers
+  - fastq
+  - db
+tools:
+  - "krakenuniq":
+      description: "Metagenomics classifier with unique k-mer counting for more specific results"
+      homepage: https://github.com/fbreitwieser/krakenuniq
+      documentation: https://github.com/fbreitwieser/krakenuniq
+      doi: 10.1186/s13059-018-1568-0
+      licence: ["MIT"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fastqs:
+      type: file
+      description: List of input FastQ files
+  - db:
+      type: directory
+      description: KrakenUniq database
+  - ram_chunk_size:
+      type: val
+      description: Amount of maximum amount of RAM each chunk of database that should be loaded at any one time
+      pattern: "*GB"
+  - save_output_fastqs:
+      type: boolean
+      description: |
+        If true, optional commands are added to save classified and unclassified reads
+        as fastq files
+  - save_reads_assignment:
+      type: boolean
+      description: |
+        If true, an optional command is added to save a file reporting the taxonomic
+        classification of each input read
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - classified_reads_fastq:
+      type: file
+      description: |
+        Reads classified as belonging to any of the taxa
+        on the KrakenUniq database.
+      pattern: "*.fastq.gz"
+  - unclassified_reads_fastq:
+      type: file
+      description: |
+        Reads not classified to any of the taxa
+        on the KrakenUniq database.
+      pattern: "*.fastq.gz"
+  - classified_assignment:
+      type: file
+      description: |
+        KrakenUniq output file indicating the taxonomic assignment of
+        each input read ## DOUBLE CHECK!!
+  - report:
+      type: file
+      description: |
+        KrakenUniq report containing stats about classified
+        and not classifed reads.
+      pattern: "*.report.txt"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@mjamy"
+  - "@Midnighter"

--- a/modules/nf-core/malt/run/main.nf
+++ b/modules/nf-core/malt/run/main.nf
@@ -1,0 +1,41 @@
+process MALT_RUN {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "bioconda::malt=0.61"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/malt:0.61--hdfd78af_0' :
+        'quay.io/biocontainers/malt:0.61--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fastqs)
+    path index
+
+    output:
+    tuple val(meta), path("*.rma6")                          , emit: rma6
+    tuple val(meta), path("*.{tab,text,sam}"),  optional:true, emit: alignments
+    tuple val(meta), path("*.log")                           , emit: log
+    path "versions.yml"                                      , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    malt-run \\
+        -t $task.cpus \\
+        -v \\
+        -o . \\
+        $args \\
+        --inFile ${fastqs.join(' ')} \\
+        --index $index/ |&tee ${prefix}-malt-run.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        malt: \$(malt-run --help  2>&1 | grep -o 'version.* ' | cut -f 1 -d ',' | cut -f2 -d ' ')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/malt/run/meta.yml
+++ b/modules/nf-core/malt/run/meta.yml
@@ -1,0 +1,54 @@
+name: malt_run
+description: MALT, an acronym for MEGAN alignment tool, is a sequence alignment and analysis tool designed for processing high-throughput sequencing data, especially in the context of metagenomics.
+keywords:
+  - malt
+  - alignment
+  - metagenomics
+  - ancient DNA
+  - aDNA
+  - palaeogenomics
+  - archaeogenomics
+  - microbiome
+tools:
+  - malt:
+      description: A tool for mapping metagenomic data
+      homepage: https://www.wsi.uni-tuebingen.de/lehrstuehle/algorithms-in-bioinformatics/software/malt/
+      documentation: https://software-ab.informatik.uni-tuebingen.de/download/malt/manual.pdf
+
+      doi: "10.1038/s41559-017-0446-6"
+      licence: ["GPL v3"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fastqs:
+      type: file
+      description: Input FASTQ files
+      pattern: "*.{fastq.gz,fq.gz}"
+  - index:
+      type: directory
+      description: Index/database directory from malt-build
+      pattern: "*/"
+output:
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - rma6:
+      type: file
+      description: MEGAN6 RMA6 file
+      pattern: "*.rma6"
+  - sam:
+      type: file
+      description: Alignment files in Tab, Text or MEGAN-compatible SAM format
+      pattern: "*.{tab,txt,sam}"
+  - log:
+      type: file
+      description: Log of verbose MALT stdout
+      pattern: "*-malt-run.log"
+
+authors:
+  - "@jfy133"

--- a/modules/nf-core/maltextract/main.nf
+++ b/modules/nf-core/maltextract/main.nf
@@ -1,0 +1,39 @@
+process MALTEXTRACT {
+
+    label 'process_medium'
+
+    conda "bioconda::hops=0.35"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/hops:0.35--hdfd78af_1' :
+        'quay.io/biocontainers/hops:0.35--hdfd78af_1' }"
+
+    input:
+    path rma6
+    path taxon_list
+    path ncbi_dir
+
+    output:
+    path "results"      , emit: results
+    path "versions.yml" , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    MaltExtract \\
+        -Xmx${task.memory.toGiga()}g \\
+        -p $task.cpus \\
+        -i ${rma6.join(' ')} \\
+        -t $taxon_list \\
+        -r $ncbi_dir \\
+        -o results/ \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        maltextract: \$(MaltExtract --help | head -n 2 | tail -n 1 | sed 's/MaltExtract version//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/maltextract/meta.yml
+++ b/modules/nf-core/maltextract/meta.yml
@@ -1,0 +1,51 @@
+name: maltextract
+description: Tool for evaluation of MALT results for true positives of ancient metagenomic taxonomic screening
+keywords:
+  - malt
+  - MaltExtract
+  - HOPS
+  - alignment
+  - metagenomics
+  - ancient DNA
+  - aDNA
+  - palaeogenomics
+  - archaeogenomics
+  - microbiome
+  - authentication
+  - damage
+  - edit distance
+tools:
+  - maltextract:
+      description: Java tool to work with ancient metagenomics
+      homepage: https://github.com/rhuebler/hops
+      documentation: https://github.com/rhuebler/hops
+      tool_dev_url: https://github.com/rhuebler/hops
+      doi: "10.1186/s13059-019-1903-0"
+      licence: ["GPL 3"]
+
+input:
+  - rma6:
+      type: file
+      description: RMA6 files from MALT
+      pattern: "*.rma6"
+  - taxon_list:
+      type: file
+      description: List of target taxa to evaluate
+      pattern: "*.txt"
+  - ncbi_dir:
+      type: directory
+      description: Directory containing NCBI taxonomy map and tre files
+      pattern: "${ncbi_dir}/"
+
+output:
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - results:
+      type: directory
+      description: Directory containing MaltExtract text results files
+      pattern: "*.rma6"
+
+authors:
+  - "@jfy133"

--- a/modules/nf-core/metaphlan3/metaphlan3/main.nf
+++ b/modules/nf-core/metaphlan3/metaphlan3/main.nf
@@ -1,0 +1,48 @@
+process METAPHLAN3_METAPHLAN3 {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "bioconda::metaphlan=3.0.12"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/metaphlan:3.0.12--pyhb7b1952_0' :
+        'quay.io/biocontainers/metaphlan:3.0.12--pyhb7b1952_0' }"
+
+    input:
+    tuple val(meta), path(input)
+    path metaphlan_db
+
+    output:
+    tuple val(meta), path("*_profile.txt")   ,                emit: profile
+    tuple val(meta), path("*.biom")          ,                emit: biom
+    tuple val(meta), path('*.bowtie2out.txt'), optional:true, emit: bt2out
+    path "versions.yml"                      ,                emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def input_type  = ("$input".endsWith(".fastq.gz") || "$input".endsWith(".fq.gz")) ? "--input_type fastq" :  ("$input".contains(".fasta")) ? "--input_type fasta" : ("$input".endsWith(".bowtie2out.txt")) ? "--input_type bowtie2out" : "--input_type sam"
+    def input_data  = ("$input_type".contains("fastq")) && !meta.single_end ? "${input[0]},${input[1]}" : "$input"
+    def bowtie2_out = "$input_type" == "--input_type bowtie2out" || "$input_type" == "--input_type sam" ? '' : "--bowtie2out ${prefix}.bowtie2out.txt"
+
+    """
+    BT2_DB=`find -L "${metaphlan_db}" -name "*rev.1.bt2" -exec dirname {} \\;`
+
+    metaphlan \\
+        --nproc $task.cpus \\
+        $input_type \\
+        $input_data \\
+        $args \\
+        $bowtie2_out \\
+        --bowtie2db \$BT2_DB \\
+        --biom ${prefix}.biom \\
+        --output_file ${prefix}_profile.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        metaphlan3: \$(metaphlan --version 2>&1 | awk '{print \$3}')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/metaphlan3/metaphlan3/meta.yml
+++ b/modules/nf-core/metaphlan3/metaphlan3/meta.yml
@@ -1,0 +1,58 @@
+name: metaphlan3_metaphlan3
+description: MetaPhlAn is a tool for profiling the composition of microbial communities from metagenomic shotgun sequencing data.
+keywords:
+  - metagenomics
+  - classification
+  - fastq
+  - bam
+  - fasta
+tools:
+  - metaphlan3:
+      description: Identify clades (phyla to species) present in the metagenome obtained from a microbiome sample and their relative abundance
+      homepage: https://huttenhower.sph.harvard.edu/metaphlan/
+      documentation: https://github.com/biobakery/MetaPhlAn
+      doi: "10.7554/eLife.65088"
+      licence: ["MIT License"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - input:
+      type: file
+      description: Metaphlan 3.0 can classify the metagenome from a variety of input data types, including FASTQ files (single-end and paired-end), FASTA, bowtie2-produced SAM files (produced from alignments to the MetaPHlAn marker database) and intermediate bowtie2 alignment files (bowtie2out)
+      pattern: "*.{fastq.gz, fasta, fasta.gz, sam, bowtie2out.txt}"
+  - metaphlan_db:
+      type: file
+      description: |
+        Directory containing pre-downloaded and uncompressed MetaPhlAn3 database downloaded from: http://cmprod1.cibio.unitn.it/biobakery3/metaphlan_databases/.
+        Note that you will also need to specify `--index` and the database version name (e.g. 'mpa_v31_CHOCOPhlAn_201901') in your module.conf ext.args for METAPHLAN3_METAPHLAN3!
+      pattern: "*/"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - profile:
+      type: file
+      description: Tab-separated output file of the predicted taxon relative abundances
+      pattern: "*.{txt}"
+  - biom:
+      type: file
+      description: General-use format for representing biological sample by observation contingency tables
+      pattern: "*.{biom}"
+  - bowtie2out:
+      type: file
+      description: Intermediate Bowtie2 output produced from mapping the metagenome against the MetaPHlAn marker database ( not compatible with `bowtie2out` files generated with MetaPhlAn versions below 3 )
+      pattern: "*.{bowtie2out.txt}"
+
+authors:
+  - "@MGordon09"

--- a/modules/nf-core/mtnucratio/main.nf
+++ b/modules/nf-core/mtnucratio/main.nf
@@ -1,0 +1,37 @@
+process MTNUCRATIO {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::mtnucratio=0.7"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mtnucratio:0.7--hdfd78af_2' :
+        'quay.io/biocontainers/mtnucratio:0.7--hdfd78af_2' }"
+
+    input:
+    tuple val(meta), path(bam)
+    val(mt_id)
+
+    output:
+    tuple val(meta), path("*.mtnucratio"), emit: mtnucratio
+    tuple val(meta), path("*.json")      , emit: json
+    path "versions.yml"                  , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    mtnucratio \\
+        $args \\
+        $bam \\
+        $mt_id
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        mtnucratio: \$(echo \$(mtnucratio --version 2>&1) | head -n1 | sed 's/Version: //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/mtnucratio/meta.yml
+++ b/modules/nf-core/mtnucratio/meta.yml
@@ -1,0 +1,54 @@
+name: mtnucratio
+description: A small Java tool to calculate ratios between MT and nuclear sequencing reads in a given BAM file.
+keywords:
+  - mtnucratio
+  - ratio
+  - reads
+  - bam
+  - mitochondrial to nuclear ratio
+  - mitochondria
+  - statistics
+tools:
+  - mtnucratio:
+      description: A small tool to determine MT to Nuclear ratios for NGS data.
+      homepage: https://github.com/apeltzer/MTNucRatioCalculator
+      documentation: https://github.com/apeltzer/MTNucRatioCalculator
+      tool_dev_url: https://github.com/apeltzer/MTNucRatioCalculator
+      doi: "10.1186/s13059-016-0918-z"
+      licence: ["GPL v3"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: (coordinate) sorted BAM/SAM file
+      pattern: "*.{bam,sam}"
+  - mt_id:
+      type: string
+      description: Identifier of the contig/chromosome of interest (e.g. chromosome, contig) as in the aligned against reference FASTA file, e.g. mt or chrMT for mitochondria
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - mtnucratio:
+      type: file
+      description: Text file containing metrics (mtreads, mt_cov_avg, nucreads, nuc_cov_avg, mt_nuc_ratio)
+      pattern: "*.mtnucratio"
+  - json:
+      type: file
+      description: JSON file, containing metadata map with sample name, tool name and version, and metrics as in txt file
+      pattern: "*.json"
+
+authors:
+  - "@louperelo"

--- a/modules/nf-core/prinseqplusplus/main.nf
+++ b/modules/nf-core/prinseqplusplus/main.nf
@@ -1,0 +1,61 @@
+process PRINSEQPLUSPLUS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "bioconda::prinseq-plus-plus=1.2.3"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/prinseq-plus-plus:1.2.3--hc90279e_1':
+        'quay.io/biocontainers/prinseq-plus-plus:1.2.3--hc90279e_1' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*_good_out*.fastq.gz")                  , emit: good_reads
+    tuple val(meta), path("*_single_out*.fastq.gz"), optional: true, emit: single_reads
+    tuple val(meta), path("*_bad_out*.fastq.gz")   , optional: true, emit: bad_reads
+    tuple val(meta), path("*.log")                                 , emit: log
+    path "versions.yml"                                            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    if (meta.single_end) {
+        """
+        prinseq++ \\
+            -threads $task.cpus \\
+            -fastq ${reads} \\
+            -out_name ${prefix} \\
+            -out_gz \\
+            -VERBOSE 1 \\
+            $args \\
+            | tee ${prefix}.log
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            prinseqplusplus: \$(echo \$(prinseq++ --version | cut -f 2 -d ' ' ))
+        END_VERSIONS
+        """
+    } else {
+        """
+        prinseq++ \\
+            -threads $task.cpus \\
+            -fastq ${reads[0]} \\
+            -fastq2 ${reads[1]} \\
+            -out_name ${prefix} \\
+            -out_gz \\
+            -VERBOSE 1 \\
+            $args \\
+            | tee ${prefix}.log
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            prinseqplusplus: \$(echo \$(prinseq++ --version | cut -f 2 -d ' ' ))
+        END_VERSIONS
+        """
+    }
+}

--- a/modules/nf-core/prinseqplusplus/meta.yml
+++ b/modules/nf-core/prinseqplusplus/meta.yml
@@ -1,0 +1,60 @@
+name: "prinseqplusplus"
+description: PRINSEQ++ is a C++ implementation of the prinseq-lite.pl program. It can be used to filter, reformat or trim genomic and metagenomic sequence data
+keywords:
+  - fastq
+  - fasta
+  - filter
+  - trim
+tools:
+  - "prinseqplusplus":
+      description: "PRINSEQ++ - Multi-threaded C++ sequence cleaning"
+      homepage: "https://github.com/Adrian-Cantu/PRINSEQ-plus-plus"
+      documentation: "https://github.com/Adrian-Cantu/PRINSEQ-plus-plus"
+      tool_dev_url: "https://github.com/Adrian-Cantu/PRINSEQ-plus-plus"
+      doi: "10.7287/peerj.preprints.27553v1"
+      licence: "['GPL v2']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end
+        data, respectively.
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - good_reads:
+      type: file
+      description: Reads passing filter(s) in gzipped FASTQ format
+      pattern: "*_good_out_{R1,R2}.fastq.gz"
+  - single_reads:
+      type: file
+      description: |
+        Single reads without the pair passing filter(s) in gzipped FASTQ format
+      pattern: "*_single_out_{R1,R2}.fastq.gz"
+  - bad_reads:
+      type: file
+      description: |
+        Reads without not passing filter(s) in gzipped FASTQ format
+      pattern: "*_bad_out_{R1,R2}.fastq.gz"
+  - log:
+      type: file
+      description: |
+        Verbose level 2 STDOUT information in a log file
+      pattern: "*.log"
+
+authors:
+  - "@jfy133"

--- a/nextflow.config
+++ b/nextflow.config
@@ -109,14 +109,30 @@ params {
     bamfiltering_savefilteredbams         = false // can include unmapped reads if --bamfiltering_retainunmappedgenomicbam specified
 
     // Metagenomic Screening
-    run_metagenomicscreening              = false
-    run_metagenomics_complexityfiltering  = false
-    metagenomicscreening_input            = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
-    metagenomics_complexity_tool          = 'bbduk'
-    metagenomics_complexity_savefastq     = false
-    metagenomics_complexity_entropy       = 0.3
-    metagenomics_prinseq_mode             = 'entropy'
-    metagenomics_prinseq_dustscore        = 0.5
+    run_metagenomics                                 = false
+    metagenomics_input                               = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
+    run_metagenomics_complexityfiltering             = false
+    metagenomics_complexity_tool                     = 'bbduk'
+    metagenomics_complexity_savefastq                = false
+    metagenomics_complexity_entropy                  = 0.3
+    metagenomics_prinseq_mode                        = 'entropy'
+    metagenomics_prinseq_dustscore                   = 0.5
+    metagenomics_profiling_tool                      = ''
+    metagenomics_profiling_database                  = ''
+    metagenomics_krakenuniq_ram_chunk_size           = '16G'
+    metagenomics_krakenuniq_save_reads               = false
+    metagenomics_krakenuniq_save_readclassifications = false
+    metagenomics_kraken2_save_reads                  = false
+    metagenomics_kraken2_save_readclassification     = false
+    metagenomics_kraken2_save_minimizers             = false
+    metagenomics_malt_mode                           = 'BlastN'
+    metagenomics_malt_alignment_mode                 = 'SemiGlobal'
+    metagenomics_malt_save_reads                     = false
+    metagenomics_malt_sam_output                     = false
+    metagenomics_malt_percent_identity               = 85
+    metagenomics_malt_top_percent                    = 1
+    metagenomics_malt_max_queries                    = 100
+    metagenomics_malt_memory_mode                    = 'load'
 
     // Deduplication options
     skip_deduplication = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -109,8 +109,14 @@ params {
     bamfiltering_savefilteredbams         = false // can include unmapped reads if --bamfiltering_retainunmappedgenomicbam specified
 
     // Metagenomic Screening
-    run_metagenomicscreening   = false
-    metagenomicscreening_input = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
+    run_metagenomicscreening              = false
+    run_metagenomics_complexityfiltering  = false
+    metagenomicscreening_input            = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
+    metagenomics_complexity_tool          = 'bbduk'
+    metagenomics_complexity_savefastq     = false
+    metagenomics_complexity_entropy       = 0.3
+    metagenomics_prinseq_mode             = 'entropy'
+    metagenomics_prinseq_dustscore        = 0.5
 
     // Deduplication options
     skip_deduplication = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -109,30 +109,34 @@ params {
     bamfiltering_savefilteredbams         = false // can include unmapped reads if --bamfiltering_retainunmappedgenomicbam specified
 
     // Metagenomic Screening
-    run_metagenomics                                 = false
-    metagenomics_input                               = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
-    run_metagenomics_complexityfiltering             = false
-    metagenomics_complexity_tool                     = 'bbduk'
-    metagenomics_complexity_savefastq                = false
-    metagenomics_complexity_entropy                  = 0.3
-    metagenomics_prinseq_mode                        = 'entropy'
-    metagenomics_prinseq_dustscore                   = 0.5
-    metagenomics_profiling_tool                      = ''
-    metagenomics_profiling_database                  = ''
-    metagenomics_krakenuniq_ram_chunk_size           = '16G'
-    metagenomics_krakenuniq_save_reads               = false
-    metagenomics_krakenuniq_save_readclassifications = false
-    metagenomics_kraken2_save_reads                  = false
-    metagenomics_kraken2_save_readclassification     = false
-    metagenomics_kraken2_save_minimizers             = false
-    metagenomics_malt_mode                           = 'BlastN'
-    metagenomics_malt_alignment_mode                 = 'SemiGlobal'
-    metagenomics_malt_save_reads                     = false
-    metagenomics_malt_sam_output                     = false
-    metagenomics_malt_percent_identity               = 85
-    metagenomics_malt_top_percent                    = 1
+    run_metagenomics                                  = false
+    metagenomics_input                                = 'unmapped' // mapped, all, unmapped -> mapped vs all specified in SAMTOOLS_FASTQ_MAPPED in modules.conf, unmapped hardcoded SAMTOOLS_FASTQ_UMAPPED
+    run_metagenomics_complexityfiltering              = false
+    metagenomics_complexity_tool                      = 'bbduk'
+    metagenomics_complexity_savefastq                 = false
+    metagenomics_complexity_entropy                   = 0.3
+    metagenomics_prinseq_mode                         = 'entropy'
+    metagenomics_prinseq_dustscore                    = 0.5
+    metagenomics_profiling_tool                       = null
+    metagenomics_profiling_database                   = null
+    metagenomics_krakenuniq_ram_chunk_size            = '16G'
+    metagenomics_krakenuniq_save_reads                = false
+    metagenomics_krakenuniq_save_read_classifications = false
+    metagenomics_kraken2_save_reads                   = false
+    metagenomics_kraken2_save_readclassification      = false
+    metagenomics_kraken2_save_minimizers              = false
+    metagenomics_malt_mode                            = 'BlastN'
+    metagenomics_malt_alignment_mode                  = 'SemiGlobal'
+    metagenomics_malt_save_reads                      = false
+    metagenomics_malt_sam_output                      = false
+    metagenomics_malt_min_support_mode                = 'percent'
+    metagenomics_malt_min_support_percent             = 0.01
+    metagenomics_malt_min_support_reads               = 1
+    metagenomics_malt_min_percent_identity            = 85
+    metagenomics_malt_top_percent                     = 1
     metagenomics_malt_max_queries                    = 100
     metagenomics_malt_memory_mode                    = 'load'
+    metagenomics_malt_group_size                     = 0
 
     // Deduplication options
     skip_deduplication = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -116,6 +116,10 @@ params {
     skip_deduplication = false
     deduplication_tool = 'markduplicates'
 
+    // MtNucRatio
+    run_mtnucratio = false
+    mitochondrion_header = 'MT'
+
     // Mapping statistics options
     // Preseq
     mapstats_skip_preseq         = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -544,7 +544,7 @@
                 "bamfiltering_retainunmappedgenomicbam": {
                     "type": "boolean",
                     "description": "Specify to retain unmapped reads in the BAM file used for downstream genomic analyses.",
-                    "help_text": "You can use this parameter to retain unmapped reads (optionally also length filtered) in the genomic BAM for downstream analysis. By default, the pipeline only keeps mapped reads for downstream analysis.\n\nThis is also turned on if `--metagenomics_screening_input` is set to `all`.\n\n> \u26a0\ufe0f This will likely slow down run time of downstream pipeline steps!\n\n> Modifies tool parameter(s):\n> - samtools view: `-f 4` / `-F 4`",
+                    "help_text": "You can use this parameter to retain unmapped reads (optionally also length filtered) in the genomic BAM for downstream analysis. By default, the pipeline only keeps mapped reads for downstream analysis.\n\nThis is also turned on if `--metagenomics_input` is set to `all`.\n\n> \u26a0\ufe0f This will likely slow down run time of downstream pipeline steps!\n\n> Modifies tool parameter(s):\n> - samtools view: `-f 4` / `-F 4`",
                     "fa_icon": "fas fa-piggy-bank"
                 },
                 "bamfiltering_generateunmappedfastq": {
@@ -574,13 +574,13 @@
             "description": "Options to related to metagenomic screening.",
             "default": "",
             "properties": {
-                "run_metagenomics_screening": {
+                "run_metagenomics": {
                     "type": "boolean",
                     "description": "Turn on metagenomic screening of mapped, unmapped, or all reads.",
                     "fa_icon": "fas fa-power-off",
                     "help_text": "Turns on the metagenomic screening subworkflow of the pipeline, where reads are screened against large databases. Typically used for pathogen screening or microbial community analysis.\n\nIf supplied, this will also turn on the BAM filtering subworkflow of the pipeline."
                 },
-                "metagenomics_screening_input": {
+                "metagenomics_input": {
                     "type": "string",
                     "default": "unmapped",
                     "description": "Specify which type of reads to go into metagenomic screening.",
@@ -593,53 +593,53 @@
                     "description": "Specify which tool to use for metagenomic profiling and screening.",
                     "enum": ["malt", "metaphlan2", "kraken2", "krakenuniq"],
                     "fa_icon": "fas fa-toolbox",
-                    "help_text": "Select which tool to run metagenomics profiling on designated metagenomics_screening_input. Which tool to use will depend on your specific context, as each tool uses a different method and database. See literature of the tools for recommendations"
+                    "help_text": "Select which tool to run metagenomics profiling on designated metagenomics_input. Which tool to use will depend on your specific context, as each tool uses a different method and database. See literature of the tools for recommendations"
                 },
                 "metagenomics_profiling_database": {
                     "type": "string",
                     "format": "directory-path",
                     "description": "Specify the path to a databse directory to run metagenomics profiling on. In the case of kraken2, this can be a tar.gz of the directory.",
                     "fa_icon": "fas fa-database",
-                    "help_text": "Specify your metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_screening_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
+                    "help_text": "Specify your metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
                 },
-                "metagenomics_profiling_krakenuniq_save_reads": {
+                "metagenomics_krakenuniq_save_reads": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Turn on saving of KrakenUniq-aligned reads",
                     "help_text": "Save reads that do and do not have a taxonomic classification in your output results directory in FASTQ format.\n\n> Modifies tool parameter(s):\n> - krakenuniq: `--classified-out` and `--unclassified-out`"
                 },
-                "metagenomics_profiling_krakenuniq_save_read_classifications": {
+                "metagenomics_krakenuniq_save_read_classifications": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Turn on saving of KrakenUniq per-read taxonomic assignment file",
                     "help_text": "Save a text file that contains a list of each read that had a taxonomic assignment, with information on specific taxonomic taxonomic assignment that that read recieved.\n\n> Modifies tool parameter(s):\n> - krakenuniq: `--output`"
                 },
-                "metagenomics_profiling_krakenuniq_ram_chunk_size": {
+                "metagenomics_krakenuniq_ram_chunk_size": {
                     "type": "string",
                     "default": "16G",
                     "description": "Specify how large to chunk database when loading into memory for KrakenUniq",
                     "fa_icon": "fas fa-database",
                     "help_text": "nf-core/taxprofiler utilises a 'low memory' option for KrakenUniq that can reduce the amount of RAM the process requires using the `--preloaded` option.\n\nA further extension to this option is that you can specify how large each chunk of the database should be that gets loaded into memory at any one time. You can specify the amount of RAM to chunk the database to with this parameter, and is particularly useful for people with limited computational resources.\n\nMore information about this parameter can be seen [here](https://github.com/fbreitwieser/krakenuniq/blob/master/README.md#new-release-v07).\n\n> Modifies KrakenUniq parameter: --preload-size\n\n"
                 },
-                "metagenomics_profiling_kraken2_save_reads": {
+                "metagenomics_kraken2_save_reads": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Turn on saving of Kraken2-aligned reads",
                     "help_text": "Save reads that do and do not have a taxonomic classification in your output results directory in FASTQ format.\n\n> Modifies tool parameter(s):\n> - kraken2: `--classified-out` and `--unclassified-out`"
                 },
-                "metagenomics_profiling_kraken2_save_readclassification": {
+                "metagenomics_kraken2_save_readclassification": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Turn on saving of Kraken2 per-read taxonomic assignment file",
                     "help_text": "Save a text file that contains a list of each read that had a taxonomic assignment, with information on specific taxonomic taxonomic assignment that that read recieved.\n\n> Modifies tool parameter(s):\n> - kraken2: `--output`"
                 },
-                "metagenomics_profiling_kraken2_save_minimizers": {
+                "metagenomics_kraken2_save_minimizers": {
                     "type": "boolean",
                     "description": "Turn on saving minimizer information in the kraken2 report thus increasing to an eight column layout.",
                     "fa_icon": "fas fa-save",
                     "help_text": "Turn on saving minimizer information in the kraken2 report thus increasing to an eight column layout.\n\nAdds `--report-minimizer-data` to the kraken2 command."
                 },
-                "metagenomics_profiling_malt_mode": {
+                "metagenomics_malt_mode": {
                     "type": "string",
                     "default": "BlastN",
                     "description": "Specify which alignment mode to use for MALT. Options: 'Unknown', 'BlastN', 'BlastP', 'BlastX', 'Classifier'.",
@@ -647,7 +647,7 @@
                     "help_text": "Use this to run the program in 'BlastN', 'BlastP', 'BlastX' modes to align DNA\nand DNA, protein and protein, or DNA reads against protein references\nrespectively. Ensure your database matches the mode. Check the\n[MALT\nmanual](http://ab.inf.uni-tuebingen.de/data/software/malt/download/manual.pdf)\nfor more details. Default: `'BlastN'`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-m`\n",
                     "enum": ["BlastN", "BlastP", "BlastX"]
                 },
-                "metagenomics_profiling_malt_alignment_mode": {
+                "metagenomics_malt_alignment_mode": {
                     "type": "string",
                     "default": "SemiGlobal",
                     "description": "Specify alignment method for MALT. Options: 'Local', 'SemiGlobal'.",
@@ -655,21 +655,21 @@
                     "help_text": "Specify what alignment algorithm to use. Options are 'Local' or 'SemiGlobal'. Local is a BLAST like alignment, but is much slower. Semi-global alignment aligns reads end-to-end. Default: `'SemiGlobal'`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-at`",
                     "enum": ["Local", "SemiGlobal"]
                 },
-                "metagenomics_profiling_malt_min_percent_identity": {
+                "metagenomics_malt_min_percent_identity": {
                     "type": "integer",
                     "default": 85,
                     "description": "Percent identity value threshold for MALT.",
                     "fa_icon": "fas fa-id-card",
                     "help_text": "Specify the minimum percent identity (or similarity) a sequence must have to the reference for it to be retained. Default is `85`\n\nOnly used when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-id`"
                 },
-                "metagenomics_profiling_malt_top_percent": {
+                "metagenomics_malt_top_percent": {
                     "type": "integer",
                     "default": 1,
                     "description": "Specify the percent for LCA algorithm for MALT (see MEGAN6 CE manual).",
                     "fa_icon": "fas fa-percent",
                     "help_text": "Specify the top percent value of the LCA algorithm. From the [MALT manual](http://ab.inf.uni-tuebingen.de/data/software/malt/download/manual.pdf): \"For each\nread, only those matches are used for taxonomic placement whose bit disjointScore is within\n10% of the best disjointScore for that read.\". Default: `1`.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-top`"
                 },
-                "metagenomics_profiling_malt_min_support_mode": {
+                "metagenomics_malt_min_support_mode": {
                     "type": "string",
                     "default": "percent",
                     "description": "Specify whether to use percent or raw number of reads for minimum support required for taxon to be retained for MALT. Options: 'percent', 'reads'.",
@@ -677,28 +677,28 @@
                     "help_text": "Specify whether to use a percentage, or raw number of reads as the value used to decide the minimum support a taxon requires to be retained.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-sup -supp`",
                     "enum": ["percent", "reads"]
                 },
-                "metagenomics_profiling_malt_min_support_percent": {
+                "metagenomics_malt_min_support_percent": {
                     "type": "number",
                     "default": 0.01,
                     "description": "Specify the minimum percentage of reads a taxon of sample total is required to have to be retained for MALT.",
                     "fa_icon": "fas fa-percentage",
                     "help_text": "Specify the minimum number of reads (as a percentage of all assigned reads) a given taxon is required to have to be retained as a positive 'hit' in the RMA6 file. This only applies when `--malt_min_support_mode` is set to 'percent'. Default 0.01.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-supp`"
                 },
-                "metagenomics_profiling_malt_min_support_reads": {
+                "metagenomics_malt_min_support_reads": {
                     "type": "integer",
                     "default": 1,
                     "description": "Specify a minimum number of reads a taxon of sample total is required to have to be retained in malt. Not compatible with --malt_min_support_mode 'percent'.",
                     "fa_icon": "fas fa-sort-numeric-up-alt",
                     "help_text": "Specify the minimum number of reads a given taxon is required to have to be retained as a positive 'hit'.  \nFor malt, this only applies when `--malt_min_support_mode` is set to 'reads'. Default: 1.\n\n> Modifies MALT or kraken_parse.py parameter: `-sup` and `-c` respectively\n"
                 },
-                "metagenomics_profiling_malt_max_queries": {
+                "metagenomics_malt_max_queries": {
                     "type": "integer",
                     "default": 100,
                     "description": "Specify the maximum number of queries a read can have for MALT.",
                     "fa_icon": "fas fa-phone",
                     "help_text": "Specify the maximum number of alignments a read can have. All further alignments are discarded. Default: `100`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-mq`"
                 },
-                "metagenomics_profiling_malt_memory_mode": {
+                "metagenomics_malt_memory_mode": {
                     "type": "string",
                     "default": "load",
                     "description": "Specify the memory load method. Do not use 'map' with GPFS file systems for MALT as can be very slow. Options: 'load', 'page', 'map'.",
@@ -706,24 +706,24 @@
                     "help_text": "\nHow to load the database into memory. Options are `'load'`, `'page'` or `'map'`.\n'load' directly loads the entire database into memory prior seed look up, this\nis slow but compatible with all servers/file systems. `'page'` and `'map'`\nperform a sort of 'chunked' database loading, allowing seed look up prior entire\ndatabase loading. Note that Page and Map modes do not work properly not with\nmany remote file-systems such as GPFS. Default is `'load'`.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `--memoryMode`",
                     "enum": ["load", "page", "map"]
                 },
-                "metagenomics_profiling_malt_sam_output": {
+                "metagenomics_malt_sam_output": {
                     "type": "boolean",
                     "description": "Specify to also produce SAM alignment files. Note this includes both aligned and unaligned reads, and are gzipped. Note this will result in very large file sizes.",
                     "fa_icon": "fas fa-file-alt",
                     "help_text": "Specify to _also_ produce gzipped SAM files of all alignments and un-aligned reads in addition to RMA6 files. These are **not** soft-clipped or in 'sparse' format. Can be useful for downstream analyses due to more common file format. \n\n:warning: can result in very large run output directories as this is essentially duplication of the RMA6 files.\n\n> Modifies MALT parameter `-a -f`"
                 },
-                "metagenomics_profiling_malt_save_reads": {
+                "metagenomics_malt_save_reads": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Turn on saving of MALT-aligned reads",
                     "help_text": "Turns on saving of MALT aligned reads in SAM format.\n\nNote that the SAM format produce by MALT is not completely valid, and may not work with downstream tools.\n\n> Modifies tool parameter(s):\n> - malt-run: `--alignments`, `-za`"
                 },
-                "metagenomics_profiling_malt_group_size": {
+                "metagenomics_malt_group_size": {
                     "type": "integer",
                     "default": 0,
                     "description": "Define group sizes for running multiple fastq files into malt.",
                     "fa_icon": "fas fa-barcode",
-                    "help_text": "Very large fastq files or many fastq files run through MALT at the same time can lead to excessively long runtimes. This parameter allows for parallelization of MALT runs. Please note, MALT is resource heavy and setting this value above the default will spawn N/metagenomics_profiling_malt_group_size jobs where N is the number of samples. Please only use this if it is necessary to avoid runtime limits on your HPC cluster."
+                    "help_text": "Very large fastq files or many fastq files run through MALT at the same time can lead to excessively long runtimes. This parameter allows for parallelization of MALT runs. Please note, MALT is resource heavy and setting this value above the default will spawn N/metagenomics_malt_group_size jobs where N is the number of samples. Please only use this if it is necessary to avoid runtime limits on your HPC cluster."
                 },
                 "run_metagenomics_complexityfiltering": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -590,26 +590,140 @@
                 },
                 "metagenomics_profiling_tool": {
                     "type": "string",
-                    "default": "",
                     "description": "Specify which tool to use for metagenomic profiling and screening.",
                     "enum": ["malt", "metaphlan2", "kraken2", "krakenuniq"],
-                    "fa_icon": "fas fa-hand-pointer",
+                    "fa_icon": "fas fa-toolbox",
                     "help_text": "Select which tool to run metagenomics profiling on designated metagenomics_screening_input. These tools behave vastly differently due to performing read profiling using different methods and yield vastly different reuslts."
                 },
                 "metagenomics_profiling_database": {
                     "type": "string",
                     "format": "directory-path",
-                    "default": "",
                     "description": "Specify a databse directory to run metagenomics profiling on. In the case of kraken2, this can be a tar.gz of the directory.",
-                    "fa_icon": "fas fa-hand-pointer",
+                    "fa_icon": "fas fa-database",
                     "help_text": "Select which tool to run metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_screening_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
+                },
+                "metagenomics_profiling_krakenuniq_save_reads": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of KrakenUniq-aligned reads",
+                    "help_text": "Save reads that do and do not have a taxonomic classification in your output results directory in FASTQ format.\n\n> Modifies tool parameter(s):\n> - krakenuniq: `--classified-out` and `--unclassified-out`"
+                },
+                "metagenomics_profiling_krakenuniq_save_read_classifications": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of KrakenUniq per-read taxonomic assignment file",
+                    "help_text": "Save a text file that contains a list of each read that had a taxonomic assignment, with information on specific taxonomic taxonomic assignment that that read recieved.\n\n> Modifies tool parameter(s):\n> - krakenuniq: `--output`"
+                },
+                "metagenomics_profiling_krakenuniq_ram_chunk_size": {
+                    "type": "string",
+                    "default": "16G",
+                    "description": "Specify how large to chunk database when loading into memory for KrakenUniq",
+                    "fa_icon": "fas fa-database",
+                    "help_text": "nf-core/taxprofiler utilises a 'low memory' option for KrakenUniq that can reduce the amount of RAM the process requires using the `--preloaded` option.\n\nA further extension to this option is that you can specify how large each chunk of the database should be that gets loaded into memory at any one time. You can specify the amount of RAM to chunk the database to with this parameter, and is particularly useful for people with limited computational resources.\n\nMore information about this parameter can be seen [here](https://github.com/fbreitwieser/krakenuniq/blob/master/README.md#new-release-v07).\n\n> Modifies KrakenUniq parameter: --preload-size\n\n"
+                },
+                "metagenomics_profiling_kraken2_save_reads": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of Kraken2-aligned reads",
+                    "help_text": "Save reads that do and do not have a taxonomic classification in your output results directory in FASTQ format.\n\n> Modifies tool parameter(s):\n> - kraken2: `--classified-out` and `--unclassified-out`"
+                },
+                "metagenomics_profiling_kraken2_save_readclassification": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of Kraken2 per-read taxonomic assignment file",
+                    "help_text": "Save a text file that contains a list of each read that had a taxonomic assignment, with information on specific taxonomic taxonomic assignment that that read recieved.\n\n> Modifies tool parameter(s):\n> - kraken2: `--output`"
+                },
+                "metagenomics_profiling_kraken2_save_minimizers": {
+                    "type": "boolean",
+                    "description": "Turn on saving minimizer information in the kraken2 report thus increasing to an eight column layout.",
+                    "fa_icon": "fas fa-save",
+                    "help_text": "Turn on saving minimizer information in the kraken2 report thus increasing to an eight column layout.\n\nAdds `--report-minimizer-data` to the kraken2 command."
+                },
+                "metagenomics_profiling_malt_mode": {
+                    "type": "string",
+                    "default": "BlastN",
+                    "description": "Specify which alignment mode to use for MALT. Options: 'Unknown', 'BlastN', 'BlastP', 'BlastX', 'Classifier'.",
+                    "fa_icon": "fas fa-align-left",
+                    "help_text": "Use this to run the program in 'BlastN', 'BlastP', 'BlastX' modes to align DNA\nand DNA, protein and protein, or DNA reads against protein references\nrespectively. Ensure your database matches the mode. Check the\n[MALT\nmanual](http://ab.inf.uni-tuebingen.de/data/software/malt/download/manual.pdf)\nfor more details. Default: `'BlastN'`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-m`\n",
+                    "enum": ["BlastN", "BlastP", "BlastX"]
+                },
+                "metagenomics_profiling_malt_alignment_mode": {
+                    "type": "string",
+                    "default": "SemiGlobal",
+                    "description": "Specify alignment method for MALT. Options: 'Local', 'SemiGlobal'.",
+                    "fa_icon": "fas fa-align-center",
+                    "help_text": "Specify what alignment algorithm to use. Options are 'Local' or 'SemiGlobal'. Local is a BLAST like alignment, but is much slower. Semi-global alignment aligns reads end-to-end. Default: `'SemiGlobal'`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-at`",
+                    "enum": ["Local", "SemiGlobal"]
+                },
+                "metagenomics_profiling_malt_min_percent_identity": {
+                    "type": "integer",
+                    "default": 85,
+                    "description": "Percent identity value threshold for MALT.",
+                    "fa_icon": "fas fa-id-card",
+                    "help_text": "Specify the minimum percent identity (or similarity) a sequence must have to the reference for it to be retained. Default is `85`\n\nOnly used when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-id`"
+                },
+                "metagenomics_profiling_malt_top_percent": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "Specify the percent for LCA algorithm for MALT (see MEGAN6 CE manual).",
+                    "fa_icon": "fas fa-percent",
+                    "help_text": "Specify the top percent value of the LCA algorithm. From the [MALT manual](http://ab.inf.uni-tuebingen.de/data/software/malt/download/manual.pdf): \"For each\nread, only those matches are used for taxonomic placement whose bit disjointScore is within\n10% of the best disjointScore for that read.\". Default: `1`.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-top`"
+                },
+                "metagenomics_profiling_malt_min_support_mode": {
+                    "type": "string",
+                    "default": "percent",
+                    "description": "Specify whether to use percent or raw number of reads for minimum support required for taxon to be retained for MALT. Options: 'percent', 'reads'.",
+                    "fa_icon": "fas fa-drumstick-bite",
+                    "help_text": "Specify whether to use a percentage, or raw number of reads as the value used to decide the minimum support a taxon requires to be retained.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-sup -supp`",
+                    "enum": ["percent", "reads"]
+                },
+                "metagenomics_profiling_malt_min_support_percent": {
+                    "type": "number",
+                    "default": 0.01,
+                    "description": "Specify the minimum percentage of reads a taxon of sample total is required to have to be retained for MALT.",
+                    "fa_icon": "fas fa-percentage",
+                    "help_text": "Specify the minimum number of reads (as a percentage of all assigned reads) a given taxon is required to have to be retained as a positive 'hit' in the RMA6 file. This only applies when `--malt_min_support_mode` is set to 'percent'. Default 0.01.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-supp`"
+                },
+                "metagenomics_profiling_malt_min_support_reads": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "Specify a minimum number of reads a taxon of sample total is required to have to be retained in malt. Not compatible with --malt_min_support_mode 'percent'.",
+                    "fa_icon": "fas fa-sort-numeric-up-alt",
+                    "help_text": "Specify the minimum number of reads a given taxon is required to have to be retained as a positive 'hit'.  \nFor malt, this only applies when `--malt_min_support_mode` is set to 'reads'. Default: 1.\n\n> Modifies MALT or kraken_parse.py parameter: `-sup` and `-c` respectively\n"
+                },
+                "metagenomics_profiling_malt_max_queries": {
+                    "type": "integer",
+                    "default": 100,
+                    "description": "Specify the maximum number of queries a read can have for MALT.",
+                    "fa_icon": "fas fa-phone",
+                    "help_text": "Specify the maximum number of alignments a read can have. All further alignments are discarded. Default: `100`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-mq`"
+                },
+                "metagenomics_profiling_malt_memory_mode": {
+                    "type": "string",
+                    "default": "load",
+                    "description": "Specify the memory load method. Do not use 'map' with GPFS file systems for MALT as can be very slow. Options: 'load', 'page', 'map'.",
+                    "fa_icon": "fas fa-memory",
+                    "help_text": "\nHow to load the database into memory. Options are `'load'`, `'page'` or `'map'`.\n'load' directly loads the entire database into memory prior seed look up, this\nis slow but compatible with all servers/file systems. `'page'` and `'map'`\nperform a sort of 'chunked' database loading, allowing seed look up prior entire\ndatabase loading. Note that Page and Map modes do not work properly not with\nmany remote file-systems such as GPFS. Default is `'load'`.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `--memoryMode`",
+                    "enum": ["load", "page", "map"]
+                },
+                "metagenomics_profiling_malt_sam_output": {
+                    "type": "boolean",
+                    "description": "Specify to also produce SAM alignment files. Note this includes both aligned and unaligned reads, and are gzipped. Note this will result in very large file sizes.",
+                    "fa_icon": "fas fa-file-alt",
+                    "help_text": "Specify to _also_ produce gzipped SAM files of all alignments and un-aligned reads in addition to RMA6 files. These are **not** soft-clipped or in 'sparse' format. Can be useful for downstream analyses due to more common file format. \n\n:warning: can result in very large run output directories as this is essentially duplication of the RMA6 files.\n\n> Modifies MALT parameter `-a -f`"
+                },
+                "metagenomics_profiling_malt_save_reads": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of MALT-aligned reads",
+                    "help_text": "Turns on saving of MALT aligned reads in SAM format.\n\nNote that the SAM format produce by MALT is not completely valid, and may not work with downstream tools.\n\n> Modifies tool parameter(s):\n> - malt-run: `--alignments`, `-za`"
                 },
                 "metagenomics_profiling_malt_group_size": {
                     "type": "integer",
                     "default": 0,
                     "description": "Define group sizes for running multiple fastq files into malt.",
-                    "fa_icon": "fas fa-hand-pointer",
-                    "help_text": "Very large fastq files or many fastq files run through malt at the same time can lead to excessively long runtimes. This parameter allows for parallelization of malt runs. Please note, malt is resource heavy and setting this value above the default will spawn N/metagenomics_profiling_malt_group_size jobs where N is the number of samples. Please only use this if it is necessary to avoid runtime limits on your HPC cluster."
+                    "fa_icon": "fas fa-barcode",
+                    "help_text": "Very large fastq files or many fastq files run through MALT at the same time can lead to excessively long runtimes. This parameter allows for parallelization of MALT runs. Please note, MALT is resource heavy and setting this value above the default will spawn N/metagenomics_profiling_malt_group_size jobs where N is the number of samples. Please only use this if it is necessary to avoid runtime limits on your HPC cluster."
                 },
                 "run_metagenomics_complexityfiltering": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -216,7 +219,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {
@@ -305,7 +315,10 @@
                     "default": "fastqc",
                     "description": "Specify which tool to use for sequencing quality control.",
                     "help_text": "Specify which tool to use for sequencing quality control.\n\nFalco is designed as a drop-in replacement for FastQC but written in C++ for faster computation. We recommend using falco with very large datasets (due to reduced memory constraints).",
-                    "enum": ["fastqc", "falco"],
+                    "enum": [
+                        "fastqc",
+                        "falco"
+                    ],
                     "fa_icon": "fas fa-hammer"
                 },
                 "skip_preprocessing": {
@@ -318,7 +331,10 @@
                     "type": "string",
                     "default": "fastp",
                     "description": "Specify which preprocessing tool to use.",
-                    "enum": ["fastp", "adapterremoval"],
+                    "enum": [
+                        "fastp",
+                        "adapterremoval"
+                    ],
                     "help_text": "Specify which preprocessing tool to use.\n\nAdapterRemoval is commonly used in palaeogenomics, however fastp has similar performance and has many additional functionality (including inbuilt complexity trimming) that can be often useful.",
                     "fa_icon": "fas fa-hammer"
                 },
@@ -452,7 +468,12 @@
                 "mapping_tool": {
                     "type": "string",
                     "default": "bowtie2",
-                    "enum": ["bwaaln", "bwamem", "bowtie2", "circularmapper"],
+                    "enum": [
+                        "bwaaln",
+                        "bwamem",
+                        "bowtie2",
+                        "circularmapper"
+                    ],
                     "description": "Specify which mapper to use.",
                     "help_text": "Specify which mapping tool to use. Options are BWA aln ('`bwaaln`'), BWA mem ('`bwamem`'), circularmapper ('`circularmapper`'), or bowtie2 ('`bowtie2`'). BWA aln is the default and highly suited for short-read ancient DNA. BWA mem can be quite useful for modern DNA, but is rarely used in projects for ancient DNA. CircularMapper enhances the mapping procedure to circular references, using the BWA algorithm but utilizing a extend-remap procedure (see Peltzer et al 2016, Genome Biology for details). Bowtie2 is similar to BWA aln, and has recently been suggested to provide slightly better results under certain conditions ([Poullet and Orlando 2020](https://doi.org/10.3389/fevo.2020.00105)), as well as providing extra functionality (such as FASTQ trimming). Default is 'bwaaln'\n\nMore documentation can be seen for each tool under:\n\n- [BWA aln](http://bio-bwa.sourceforge.net/bwa.shtml#3)\n- [BWA mem](http://bio-bwa.sourceforge.net/bwa.shtml#3)\n- [CircularMapper](https://circularmapper.readthedocs.io/en/latest/contents/userguide.html)\n- [Bowtie2](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml#command-line)",
                     "fa_icon": "fas fa-layer-group"
@@ -584,7 +605,11 @@
                     "type": "string",
                     "default": "unmapped",
                     "description": "Specify which type of reads to go into metagenomic screening.",
-                    "enum": ["unmapped", "mapped", "all"],
+                    "enum": [
+                        "unmapped",
+                        "mapped",
+                        "all"
+                    ],
                     "fa_icon": "fas fa-hand-pointer",
                     "help_text": "You can select which reads coming out of the read alignment step will be sent for metagenomic analysis.\n\nThis influences which reads are sent to this step, whether you want unmapped reads (used in most cases, as 'host reads' can often be contaminants in microbial genomes), mapped reads (e.g, when doing competitive against a genomic reference of multiple genomes and which to apply LCA correction), or all reads.\n\n> \u26a0\ufe0f If you skip paired-end merging, all reads will be screened as independent reads - not as pairs! - as all FASTQ files from BAM filtering are merged into one. This merged file is _not_ saved in results directory.\n\n> Modifies tool parameter(s):\n> - samtools fastq: `-f 4` / `-F 4`"
                 },
@@ -741,7 +766,10 @@
                     "type": "string",
                     "default": "bbduk",
                     "description": "Specify which tool to use for trimming, filtering, or reformatting of fastq reads that go into metagenomics screening.",
-                    "enum": ["bbduk", "prinseq"],
+                    "enum": [
+                        "bbduk",
+                        "prinseq"
+                    ],
                     "fa_icon": "fas fa-hand-pointer",
                     "help_text": "You can select which tool is used to generate a final set of reads for the metagenomic classifier after any necessary trimming, filtering or reformatting of the reads.\n\nThis intermediate file is not saved in the results directory, unless marked with `--metagenomics_complexity_savefastq`."
                 },
@@ -755,7 +783,10 @@
                 "metagenomics_prinseq_mode": {
                     "type": "string",
                     "default": "entropy",
-                    "enum": ["entropy", "dust"],
+                    "enum": [
+                        "entropy",
+                        "dust"
+                    ],
                     "fa_icon": "fas fa-check-square",
                     "description": "Specify the complexity filter mode for PRINSEQ++",
                     "help_text": "Specify the complexity filter mode for PRINSEQ++ \n\nUse the selected mode together with the correct flag:\n'dust' requires the `--metagenomics_prinseq_dustscore` parameter set\n'entropy' requires the `--metagenomics_complexity_entropy` parameter set\n\n> Sets one of the tool parameter(s):\n> - PRINSEQ++:  `-lc_entropy`\n> - PRINSEQ++:  `-lc_dust`"
@@ -766,6 +797,162 @@
                     "fa_icon": "fas fa-head-side-mask",
                     "description": "Specify the minimum dust score for PRINTSEQ++ complexity filtering",
                     "help_text": "Specify the minimum dust score below which low-complexity reads will be removed. A DUST score is based on how often different tri-nucleotides occur along a read.\n\n> Modifies tool parameter(s):\n> - PRINSEQ++: `--lc_dust`"
+                },
+                "metagenomics_profiling_tool": {
+                    "type": "string",
+                    "description": "Specify which tool to use for metagenomic profiling and screening.",
+                    "enum": [
+                        "malt",
+                        "metaphlan2",
+                        "kraken2",
+                        "krakenuniq"
+                    ],
+                    "fa_icon": "fas fa-toolbox",
+                    "help_text": "Select which tool to run metagenomics profiling on designated metagenomics_screening_input. These tools behave vastly differently due to performing read profiling using different methods and yield vastly different reuslts."
+                },
+                "metagenomics_profiling_database": {
+                    "type": "string",
+                    "format": "directory-path",
+                    "description": "Specify a databse directory to run metagenomics profiling on. In the case of kraken2, this can be a tar.gz of the directory.",
+                    "fa_icon": "fas fa-database",
+                    "help_text": "Select which tool to run metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_screening_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
+                },
+                "metagenomics_profiling_krakenuniq_save_reads": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of KrakenUniq-aligned reads",
+                    "help_text": "Save reads that do and do not have a taxonomic classification in your output results directory in FASTQ format.\n\n> Modifies tool parameter(s):\n> - krakenuniq: `--classified-out` and `--unclassified-out`"
+                },
+                "metagenomics_profiling_krakenuniq_save_read_classifications": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of KrakenUniq per-read taxonomic assignment file",
+                    "help_text": "Save a text file that contains a list of each read that had a taxonomic assignment, with information on specific taxonomic taxonomic assignment that that read recieved.\n\n> Modifies tool parameter(s):\n> - krakenuniq: `--output`"
+                },
+                "metagenomics_profiling_krakenuniq_ram_chunk_size": {
+                    "type": "string",
+                    "default": "16G",
+                    "description": "Specify how large to chunk database when loading into memory for KrakenUniq",
+                    "fa_icon": "fas fa-database",
+                    "help_text": "nf-core/taxprofiler utilises a 'low memory' option for KrakenUniq that can reduce the amount of RAM the process requires using the `--preloaded` option.\n\nA further extension to this option is that you can specify how large each chunk of the database should be that gets loaded into memory at any one time. You can specify the amount of RAM to chunk the database to with this parameter, and is particularly useful for people with limited computational resources.\n\nMore information about this parameter can be seen [here](https://github.com/fbreitwieser/krakenuniq/blob/master/README.md#new-release-v07).\n\n> Modifies KrakenUniq parameter: --preload-size\n\n"
+                },
+                "metagenomics_profiling_kraken2_save_reads": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of Kraken2-aligned reads",
+                    "help_text": "Save reads that do and do not have a taxonomic classification in your output results directory in FASTQ format.\n\n> Modifies tool parameter(s):\n> - kraken2: `--classified-out` and `--unclassified-out`"
+                },
+                "metagenomics_profiling_kraken2_save_readclassification": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of Kraken2 per-read taxonomic assignment file",
+                    "help_text": "Save a text file that contains a list of each read that had a taxonomic assignment, with information on specific taxonomic taxonomic assignment that that read recieved.\n\n> Modifies tool parameter(s):\n> - kraken2: `--output`"
+                },
+                "metagenomics_profiling_kraken2_save_minimizers": {
+                    "type": "boolean",
+                    "description": "Turn on saving minimizer information in the kraken2 report thus increasing to an eight column layout.",
+                    "fa_icon": "fas fa-save",
+                    "help_text": "Turn on saving minimizer information in the kraken2 report thus increasing to an eight column layout.\n\nAdds `--report-minimizer-data` to the kraken2 command."
+                },
+                "metagenomics_profiling_malt_mode": {
+                    "type": "string",
+                    "default": "BlastN",
+                    "description": "Specify which alignment mode to use for MALT. Options: 'Unknown', 'BlastN', 'BlastP', 'BlastX', 'Classifier'.",
+                    "fa_icon": "fas fa-align-left",
+                    "help_text": "Use this to run the program in 'BlastN', 'BlastP', 'BlastX' modes to align DNA\nand DNA, protein and protein, or DNA reads against protein references\nrespectively. Ensure your database matches the mode. Check the\n[MALT\nmanual](http://ab.inf.uni-tuebingen.de/data/software/malt/download/manual.pdf)\nfor more details. Default: `'BlastN'`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-m`\n",
+                    "enum": [
+                        "BlastN",
+                        "BlastP",
+                        "BlastX"
+                    ]
+                },
+                "metagenomics_profiling_malt_alignment_mode": {
+                    "type": "string",
+                    "default": "SemiGlobal",
+                    "description": "Specify alignment method for MALT. Options: 'Local', 'SemiGlobal'.",
+                    "fa_icon": "fas fa-align-center",
+                    "help_text": "Specify what alignment algorithm to use. Options are 'Local' or 'SemiGlobal'. Local is a BLAST like alignment, but is much slower. Semi-global alignment aligns reads end-to-end. Default: `'SemiGlobal'`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-at`",
+                    "enum": [
+                        "Local",
+                        "SemiGlobal"
+                    ]
+                },
+                "metagenomics_profiling_malt_min_percent_identity": {
+                    "type": "integer",
+                    "default": 85,
+                    "description": "Percent identity value threshold for MALT.",
+                    "fa_icon": "fas fa-id-card",
+                    "help_text": "Specify the minimum percent identity (or similarity) a sequence must have to the reference for it to be retained. Default is `85`\n\nOnly used when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-id`"
+                },
+                "metagenomics_profiling_malt_top_percent": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "Specify the percent for LCA algorithm for MALT (see MEGAN6 CE manual).",
+                    "fa_icon": "fas fa-percent",
+                    "help_text": "Specify the top percent value of the LCA algorithm. From the [MALT manual](http://ab.inf.uni-tuebingen.de/data/software/malt/download/manual.pdf): \"For each\nread, only those matches are used for taxonomic placement whose bit disjointScore is within\n10% of the best disjointScore for that read.\". Default: `1`.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-top`"
+                },
+                "metagenomics_profiling_malt_min_support_mode": {
+                    "type": "string",
+                    "default": "percent",
+                    "description": "Specify whether to use percent or raw number of reads for minimum support required for taxon to be retained for MALT. Options: 'percent', 'reads'.",
+                    "fa_icon": "fas fa-drumstick-bite",
+                    "help_text": "Specify whether to use a percentage, or raw number of reads as the value used to decide the minimum support a taxon requires to be retained.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-sup -supp`",
+                    "enum": [
+                        "percent",
+                        "reads"
+                    ]
+                },
+                "metagenomics_profiling_malt_min_support_percent": {
+                    "type": "number",
+                    "default": 0.01,
+                    "description": "Specify the minimum percentage of reads a taxon of sample total is required to have to be retained for MALT.",
+                    "fa_icon": "fas fa-percentage",
+                    "help_text": "Specify the minimum number of reads (as a percentage of all assigned reads) a given taxon is required to have to be retained as a positive 'hit' in the RMA6 file. This only applies when `--malt_min_support_mode` is set to 'percent'. Default 0.01.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-supp`"
+                },
+                "metagenomics_profiling_malt_min_support_reads": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "Specify a minimum number of reads a taxon of sample total is required to have to be retained in malt. Not compatible with --malt_min_support_mode 'percent'.",
+                    "fa_icon": "fas fa-sort-numeric-up-alt",
+                    "help_text": "Specify the minimum number of reads a given taxon is required to have to be retained as a positive 'hit'.  \nFor malt, this only applies when `--malt_min_support_mode` is set to 'reads'. Default: 1.\n\n> Modifies MALT or kraken_parse.py parameter: `-sup` and `-c` respectively\n"
+                },
+                "metagenomics_profiling_malt_max_queries": {
+                    "type": "integer",
+                    "default": 100,
+                    "description": "Specify the maximum number of queries a read can have for MALT.",
+                    "fa_icon": "fas fa-phone",
+                    "help_text": "Specify the maximum number of alignments a read can have. All further alignments are discarded. Default: `100`\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `-mq`"
+                },
+                "metagenomics_profiling_malt_memory_mode": {
+                    "type": "string",
+                    "default": "load",
+                    "description": "Specify the memory load method. Do not use 'map' with GPFS file systems for MALT as can be very slow. Options: 'load', 'page', 'map'.",
+                    "fa_icon": "fas fa-memory",
+                    "help_text": "\nHow to load the database into memory. Options are `'load'`, `'page'` or `'map'`.\n'load' directly loads the entire database into memory prior seed look up, this\nis slow but compatible with all servers/file systems. `'page'` and `'map'`\nperform a sort of 'chunked' database loading, allowing seed look up prior entire\ndatabase loading. Note that Page and Map modes do not work properly not with\nmany remote file-systems such as GPFS. Default is `'load'`.\n\nOnly when `--metagenomic_tool malt` is also supplied.\n\n> Modifies MALT parameter: `--memoryMode`",
+                    "enum": [
+                        "load",
+                        "page",
+                        "map"
+                    ]
+                },
+                "metagenomics_profiling_malt_sam_output": {
+                    "type": "boolean",
+                    "description": "Specify to also produce SAM alignment files. Note this includes both aligned and unaligned reads, and are gzipped. Note this will result in very large file sizes.",
+                    "fa_icon": "fas fa-file-alt",
+                    "help_text": "Specify to _also_ produce gzipped SAM files of all alignments and un-aligned reads in addition to RMA6 files. These are **not** soft-clipped or in 'sparse' format. Can be useful for downstream analyses due to more common file format. \n\n:warning: can result in very large run output directories as this is essentially duplication of the RMA6 files.\n\n> Modifies MALT parameter `-a -f`"
+                },
+                "metagenomics_profiling_malt_save_reads": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Turn on saving of MALT-aligned reads",
+                    "help_text": "Turns on saving of MALT aligned reads in SAM format.\n\nNote that the SAM format produce by MALT is not completely valid, and may not work with downstream tools.\n\n> Modifies tool parameter(s):\n> - malt-run: `--alignments`, `-za`"
+                },
+                "metagenomics_profiling_malt_group_size": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Define group sizes for running multiple fastq files into malt.",
+                    "fa_icon": "fas fa-barcode",
+                    "help_text": "Very large fastq files or many fastq files run through MALT at the same time can lead to excessively long runtimes. This parameter allows for parallelization of MALT runs. Please note, MALT is resource heavy and setting this value above the default will spawn N/metagenomics_profiling_malt_group_size jobs where N is the number of samples. Please only use this if it is necessary to avoid runtime limits on your HPC cluster."
                 }
             },
             "fa_icon": "fas fa-search"
@@ -786,7 +973,10 @@
                     "default": "markduplicates",
                     "description": "Specify which tool to use for deduplication.",
                     "help_text": "Sets the duplicate read removal tool. By default uses `markduplicates` from Picard. Alternatively an ancient DNA specific read deduplication tool `dedup` (Peltzer et al. 2016) is offered. The latter utilises both ends of paired-end data to remove duplicates (i.e. true exact duplicates, as markduplicates will over-zealously deduplicate anything with the same starting position even if the ends are different).\n\n> \u26a0\ufe0f DeDup can only be used on collapsed (i.e. merged) reads from paired-end sequencing.",
-                    "enum": ["markduplicates", "dedup"],
+                    "enum": [
+                        "markduplicates",
+                        "dedup"
+                    ],
                     "fa_icon": "fas fa-layer-group"
                 }
             },
@@ -833,7 +1023,10 @@
                     "help_text": "Specify which mode of preseq to run.\n\nFrom the [PreSeq documentation](http://smithlabresearch.org/wp-content/uploads/manual.pdf):\n\nc curve is used to compute the expected complexity curve of a mapped read file with a hypergeometric formula\n\nlc extrap is used to generate the expected yield for theoretical larger experiments and bounds on the number of distinct reads in the library and the associated confidence intervals, which is computed by bootstrapping the observed duplicate counts histogram.",
                     "description": "Specify which mode of preseq to run.",
                     "fa_icon": "fas fa-toggle-on",
-                    "enum": ["c_curve", "lc_extrap"]
+                    "enum": [
+                        "c_curve",
+                        "lc_extrap"
+                    ]
                 },
                 "mapstats_preseq_stepsize": {
                     "type": "integer",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -593,7 +593,7 @@
                     "description": "Specify which tool to use for metagenomic profiling and screening.",
                     "enum": ["malt", "metaphlan2", "kraken2", "krakenuniq"],
                     "fa_icon": "fas fa-toolbox",
-                    "help_text": "Select which tool to run metagenomics profiling on designated metagenomics_screening_input. These tools behave vastly differently due to performing read profiling using different methods and yield vastly different reuslts."
+                    "help_text": "Select which tool to run metagenomics profiling on designated metagenomics_screening_input. Which tool to use will depend on your specific context, as each tool uses a different method and database. See literature of the tools for recommendations"
                 },
                 "metagenomics_profiling_database": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -598,7 +598,7 @@
                 "metagenomics_profiling_database": {
                     "type": "string",
                     "format": "directory-path",
-                    "description": "Specify a databse directory to run metagenomics profiling on. In the case of kraken2, this can be a tar.gz of the directory.",
+                    "description": "Specify the path to a databse directory to run metagenomics profiling on. In the case of kraken2, this can be a tar.gz of the directory.",
                     "fa_icon": "fas fa-database",
                     "help_text": "Specify your metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_screening_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -613,6 +613,29 @@
             },
             "fa_icon": "fas fa-clone"
         },
+        "mitochondrial_to_nuclear_ratio": {
+            "title": "Mitochondrial to Nuclear Ratio",
+            "type": "object",
+            "description": "Options for the calculation of ratio of reads to one chromosome/FASTA entry against all others.",
+            "default": "",
+            "help_text": "If using TSV input, Mitochondrial to Nuclear Ratio calculation is calculated per deduplicated library (after lane merging)",
+            "fa_icon": "fas fa-balance-scale-left",
+            "properties": {
+                "run_mtnucratio": {
+                    "type": "boolean",
+                    "description": "Turn on mitochondrial to nuclear ratio calculation.",
+                    "help_text": "Turn on the module to estimate the ratio of mitochondrial to nuclear reads.",
+                    "fa_icon": "fas fa-balance-scale-left"
+                },
+                "mitochondrion_header": {
+                    "type": "string",
+                    "default": "MT",
+                    "description": "Specify the name of the reference FASTA entry corresponding to the mitochondrial genome (up to the first space).",
+                    "help_text": "Specify the FASTA entry in the reference file specified as --fasta, which acts as the mitochondrial 'chromosome' to base the ratio calculation on. The tool only accepts the first section of the header before the first space. The default chromosome name is based on hs37d5/GrCH37 human reference genome.",
+                    "fa_icon": "fas fa-heading"
+                }
+            }
+        },
         "mapping_statistics": {
             "title": "Mapping statistics",
             "type": "object",
@@ -708,6 +731,9 @@
         },
         {
             "$ref": "#/definitions/deduplication"
+        },
+        {
+            "$ref": "#/definitions/mitochondrial_to_nuclear_ratio"
         },
         {
             "$ref": "#/definitions/mapping_statistics"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -544,7 +544,7 @@
                 "bamfiltering_retainunmappedgenomicbam": {
                     "type": "boolean",
                     "description": "Specify to retain unmapped reads in the BAM file used for downstream genomic analyses.",
-                    "help_text": "You can use this parameter to retain unmapped reads (optionally also length filtered) in the genomic BAM for downstream analysis. By default, the pipeline only keeps mapped reads for downstream analysis.\n\nThis is also turned on if `--metagenomicscreening_input` is set to `all`.\n\n> \u26a0\ufe0f This will likely slow down run time of downstream pipeline steps!\n\n> Modifies tool parameter(s):\n> - samtools view: `-f 4` / `-F 4`",
+                    "help_text": "You can use this parameter to retain unmapped reads (optionally also length filtered) in the genomic BAM for downstream analysis. By default, the pipeline only keeps mapped reads for downstream analysis.\n\nThis is also turned on if `--metagenomics_screening_input` is set to `all`.\n\n> \u26a0\ufe0f This will likely slow down run time of downstream pipeline steps!\n\n> Modifies tool parameter(s):\n> - samtools view: `-f 4` / `-F 4`",
                     "fa_icon": "fas fa-piggy-bank"
                 },
                 "bamfiltering_generateunmappedfastq": {
@@ -574,19 +574,42 @@
             "description": "Options to related to metagenomic screening.",
             "default": "",
             "properties": {
-                "run_metagenomicscreening": {
+                "run_metagenomics_screening": {
                     "type": "boolean",
                     "description": "Turn on metagenomic screening of mapped, unmapped, or all reads.",
                     "fa_icon": "fas fa-power-off",
                     "help_text": "Turns on the metagenomic screening subworkflow of the pipeline, where reads are screened against large databases. Typically used for pathogen screening or microbial community analysis.\n\nIf supplied, this will also turn on the BAM filtering subworkflow of the pipeline."
                 },
-                "metagenomicscreening_input": {
+                "metagenomics_screening_input": {
                     "type": "string",
                     "default": "unmapped",
                     "description": "Specify which type of reads to go into metagenomic screening.",
                     "enum": ["unmapped", "mapped", "all"],
                     "fa_icon": "fas fa-hand-pointer",
                     "help_text": "You can select which reads coming out of the read alignment step will be sent for metagenomic analysis.\n\nThis influences which reads are sent to this step, whether you want unmapped reads (used in most cases, as 'host reads' can often be contaminants in microbial genomes), mapped reads (e.g, when doing competitive against a genomic reference of multiple genomes and which to apply LCA correction), or all reads.\n\n> \u26a0\ufe0f If you skip paired-end merging, all reads will be screened as independent reads - not as pairs! - as all FASTQ files from BAM filtering are merged into one. This merged file is _not_ saved in results directory.\n\n> Modifies tool parameter(s):\n> - samtools fastq: `-f 4` / `-F 4`"
+                },
+                "metagenomics_profiling_tool": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Specify which tool to use for metagenomic profiling and screening.",
+                    "enum": ["malt", "metaphlan2", "kraken2", "krakenuniq"],
+                    "fa_icon": "fas fa-hand-pointer",
+                    "help_text": "Select which tool to run metagenomics profiling on designated metagenomics_screening_input. These tools behave vastly differently due to performing read profiling using different methods and yield vastly different reuslts."
+                },
+                "metagenomics_profiling_database": {
+                    "type": "string",
+                    "format": "directory-path",
+                    "default": "",
+                    "description": "Specify a databse directory to run metagenomics profiling on. In the case of kraken2, this can be a tar.gz of the directory.",
+                    "fa_icon": "fas fa-hand-pointer",
+                    "help_text": "Select which tool to run metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_screening_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
+                },
+                "metagenomics_profiling_malt_group_size": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Define group sizes for running multiple fastq files into malt.",
+                    "fa_icon": "fas fa-hand-pointer",
+                    "help_text": "Very large fastq files or many fastq files run through malt at the same time can lead to excessively long runtimes. This parameter allows for parallelization of malt runs. Please note, malt is resource heavy and setting this value above the default will spawn N/metagenomics_profiling_malt_group_size jobs where N is the number of samples. Please only use this if it is necessary to avoid runtime limits on your HPC cluster."
                 },
                 "run_metagenomics_complexityfiltering": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -600,7 +600,7 @@
                     "format": "directory-path",
                     "description": "Specify a databse directory to run metagenomics profiling on. In the case of kraken2, this can be a tar.gz of the directory.",
                     "fa_icon": "fas fa-database",
-                    "help_text": "Select which tool to run metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_screening_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
+                    "help_text": "Specify your metagenomics profiling database to use with the designated metagenomics_profiling_tool on the selected metagenomics_screening_input. These databases are NOT cross-compatible and need to be pre-built/downloaded for use in nf-core/eager. Database construction is often a balancing act between breadth of sequence diversity and size."
                 },
                 "metagenomics_profiling_krakenuniq_save_reads": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -587,6 +587,48 @@
                     "enum": ["unmapped", "mapped", "all"],
                     "fa_icon": "fas fa-hand-pointer",
                     "help_text": "You can select which reads coming out of the read alignment step will be sent for metagenomic analysis.\n\nThis influences which reads are sent to this step, whether you want unmapped reads (used in most cases, as 'host reads' can often be contaminants in microbial genomes), mapped reads (e.g, when doing competitive against a genomic reference of multiple genomes and which to apply LCA correction), or all reads.\n\n> \u26a0\ufe0f If you skip paired-end merging, all reads will be screened as independent reads - not as pairs! - as all FASTQ files from BAM filtering are merged into one. This merged file is _not_ saved in results directory.\n\n> Modifies tool parameter(s):\n> - samtools fastq: `-f 4` / `-F 4`"
+                },
+                "run_metagenomics_complexityfiltering": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-power-off",
+                    "help_text": "Turns on a subworkflow of the pipeline that filters the fastq-files for complexity before the metagenomics profiling\nUse the metagenomics_complexity_tool parameter to select a method",
+                    "description": "Run a complexity filter on the metagenomics input files before classification. Specifiy the tool to use with the `metagenomics_complexity_tool` parameter, save with `metagenomics_complexity_savefastq`"
+                },
+                "metagenomics_complexity_savefastq": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Save FASTQ files containing the complexity filtered reads (before metagenomic classification).",
+                    "help_text": "Save the complexity-filtered fastq-files to the results directory"
+                },
+                "metagenomics_complexity_tool": {
+                    "type": "string",
+                    "default": "bbduk",
+                    "description": "Specify which tool to use for trimming, filtering, or reformatting of fastq reads that go into metagenomics screening.",
+                    "enum": ["bbduk", "prinseq"],
+                    "fa_icon": "fas fa-hand-pointer",
+                    "help_text": "You can select which tool is used to generate a final set of reads for the metagenomic classifier after any necessary trimming, filtering or reformatting of the reads.\n\nThis intermediate file is not saved in the results directory, unless marked with `--metagenomics_complexity_savefastq`."
+                },
+                "metagenomics_complexity_entropy": {
+                    "type": "number",
+                    "fa_icon": "fas fa-sort-numeric-up",
+                    "description": "Specify the entropy threshold that under which a sequencing read will be complexity filtered out. This should be between 0-1.",
+                    "default": 0.3,
+                    "help_text": "Specify the minimum 'entropy' value for complexity filtering for the BBDuk or PRINSEQ++ tools.\n\nThis value will only be used for PRINSEQ++ if `--metagenomics_prinseq_mode` is set to `entropy`.\n\nEntropy here corresponds to the amount of sequence variation exists within the read. Higher values correspond to more variety, and thus will likely result in more specific matching to a taxon's reference genome. The trade off here is fewer reads (or abundance information) available for having a confident identification.\n\n> Modifies tool parameter(s):\n> - BBDuk: `entropy=`\n> - PRINSEQ++:  `-lc_entropy`\n\n"
+                },
+                "metagenomics_prinseq_mode": {
+                    "type": "string",
+                    "default": "entropy",
+                    "enum": ["entropy", "dust"],
+                    "fa_icon": "fas fa-check-square",
+                    "description": "Specify the complexity filter mode for PRINSEQ++",
+                    "help_text": "Specify the complexity filter mode for PRINSEQ++ \n\nUse the selected mode together with the correct flag:\n'dust' requires the `--metagenomics_prinseq_dustscore` parameter set\n'entropy' requires the `--metagenomics_complexity_entropy` parameter set\n\n> Sets one of the tool parameter(s):\n> - PRINSEQ++:  `-lc_entropy`\n> - PRINSEQ++:  `-lc_dust`"
+                },
+                "metagenomics_prinseq_dustscore": {
+                    "type": "number",
+                    "default": 0.5,
+                    "fa_icon": "fas fa-head-side-mask",
+                    "description": "Specify the minimum dust score for PRINTSEQ++ complexity filtering",
+                    "help_text": "Specify the minimum dust score below which low-complexity reads will be removed. A DUST score is based on how often different tri-nucleotides occur along a read.\n\n> Modifies tool parameter(s):\n> - PRINSEQ++: `--lc_dust`"
                 }
             },
             "fa_icon": "fas fa-search"

--- a/subworkflows/local/bamfiltering.nf
+++ b/subworkflows/local/bamfiltering.nf
@@ -120,6 +120,7 @@ workflow FILTER_BAM {
     } else if ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' )) {
         ch_fastq_for_metagenomics = SAMTOOLS_FASTQ_MAPPED.out.other
     } else if ( !params.run_metagenomics_screening ) {
+    } else if ( !params.run_metagenomics_screening ) {
         ch_fastq_for_metagenomics = Channel.empty()
     }
 

--- a/subworkflows/local/bamfiltering.nf
+++ b/subworkflows/local/bamfiltering.nf
@@ -69,19 +69,19 @@ workflow FILTER_BAM {
     //
 
     // Generate unmapped bam (no additional filtering) if the unmapped bam OR unmapped for metagneomics selected
-    if ( params.bamfiltering_generateunmappedfastq || ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) ) {
+    if ( params.bamfiltering_generateunmappedfastq || ( params.run_metagenomics && params.metagenomics_input == 'unmapped' ) ) {
         SAMTOOLS_FASTQ_UNMAPPED ( bam.map{[ it[0], it[1] ]}, false )
         ch_versions = ch_versions.mix( SAMTOOLS_FASTQ_UNMAPPED.out.versions.first() )
     }
 
     // Solution to the Andrades Valtueña-Light Problem: mapped bam for metagenomics (with options for quality- and length filtered)
 
-    if ( params.bamfiltering_generatemappedfastq ||  ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) ) {
+    if ( params.bamfiltering_generatemappedfastq ||  ( params.run_metagenomics && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) ) {
         SAMTOOLS_FASTQ_MAPPED ( bam.map{[ it[0], it[1] ]}, false )
         ch_versions = ch_versions.mix( SAMTOOLS_FASTQ_MAPPED.out.versions.first() )
     }
 
-    if ( ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
+    if ( ( params.run_metagenomics && params.metagenomics_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
         ch_paired_fastq_for_cat = SAMTOOLS_FASTQ_UNMAPPED.out.fastq
                                     .mix(SAMTOOLS_FASTQ_UNMAPPED.out.singleton)
                                     .mix(SAMTOOLS_FASTQ_UNMAPPED.out.other)
@@ -96,7 +96,7 @@ workflow FILTER_BAM {
     }
 
     // TODO: see request https://github.com/nf-core/eager/issues/945
-    if ( ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
+    if ( ( params.run_metagenomics && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
         ch_paired_fastq_for_cat = SAMTOOLS_FASTQ_UNMAPPED.out.fastq
                                     .mix(SAMTOOLS_FASTQ_MAPPED.out.singleton)
                                     .mix(SAMTOOLS_FASTQ_MAPPED.out.other)
@@ -111,16 +111,15 @@ workflow FILTER_BAM {
     }
 
     // Routing for metagenomic screening -> first accounting for paired-end mapping, then merged mapping, then no metagenomics
-    if ( ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
+    if ( ( params.run_metagenomics && params.metagenomics_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
         ch_fastq_for_metagenomics = CAT_FASTQ_UNMAPPED.out.reads
-    } else if ( ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
+    } else if ( ( params.run_metagenomics && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
         ch_fastq_for_metagenomics = CAT_FASTQ_UNMAPPED.out.reads
-    } else if ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) {
+    } else if ( params.run_metagenomics && params.metagenomics_input == 'unmapped' ) {
         ch_fastq_for_metagenomics = SAMTOOLS_FASTQ_UNMAPPED.out.other
-    } else if ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' )) {
+    } else if ( params.run_metagenomics && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' )) {
         ch_fastq_for_metagenomics = SAMTOOLS_FASTQ_MAPPED.out.other
-    } else if ( !params.run_metagenomics_screening ) {
-    } else if ( !params.run_metagenomics_screening ) {
+    } else if ( !params.run_metagenomics ) {
         ch_fastq_for_metagenomics = Channel.empty()
     }
 

--- a/subworkflows/local/bamfiltering.nf
+++ b/subworkflows/local/bamfiltering.nf
@@ -69,19 +69,19 @@ workflow FILTER_BAM {
     //
 
     // Generate unmapped bam (no additional filtering) if the unmapped bam OR unmapped for metagneomics selected
-    if ( params.bamfiltering_generateunmappedfastq || ( params.run_metagenomicscreening && params.metagenomicscreening_input == 'unmapped' ) ) {
+    if ( params.bamfiltering_generateunmappedfastq || ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) ) {
         SAMTOOLS_FASTQ_UNMAPPED ( bam.map{[ it[0], it[1] ]}, false )
         ch_versions = ch_versions.mix( SAMTOOLS_FASTQ_UNMAPPED.out.versions.first() )
     }
 
     // Solution to the Andrades Valtueña-Light Problem: mapped bam for metagenomics (with options for quality- and length filtered)
 
-    if ( params.bamfiltering_generatemappedfastq ||  ( params.run_metagenomicscreening && ( params.metagenomicscreening_input == 'mapped' || params.metagenomicscreening_input == 'all' ) ) ) {
+    if ( params.bamfiltering_generatemappedfastq ||  ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) ) {
         SAMTOOLS_FASTQ_MAPPED ( bam.map{[ it[0], it[1] ]}, false )
         ch_versions = ch_versions.mix( SAMTOOLS_FASTQ_MAPPED.out.versions.first() )
     }
 
-    if ( ( params.run_metagenomicscreening && params.metagenomicscreening_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
+    if ( ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
         ch_paired_fastq_for_cat = SAMTOOLS_FASTQ_UNMAPPED.out.fastq
                                     .mix(SAMTOOLS_FASTQ_UNMAPPED.out.singleton)
                                     .mix(SAMTOOLS_FASTQ_UNMAPPED.out.other)
@@ -96,7 +96,7 @@ workflow FILTER_BAM {
     }
 
     // TODO: see request https://github.com/nf-core/eager/issues/945
-    if ( ( params.run_metagenomicscreening && ( params.metagenomicscreening_input == 'mapped' || params.metagenomicscreening_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
+    if ( ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
         ch_paired_fastq_for_cat = SAMTOOLS_FASTQ_UNMAPPED.out.fastq
                                     .mix(SAMTOOLS_FASTQ_MAPPED.out.singleton)
                                     .mix(SAMTOOLS_FASTQ_MAPPED.out.other)
@@ -111,15 +111,15 @@ workflow FILTER_BAM {
     }
 
     // Routing for metagenomic screening -> first accounting for paired-end mapping, then merged mapping, then no metagenomics
-    if ( ( params.run_metagenomicscreening && params.metagenomicscreening_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
+    if ( ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) && params.preprocessing_skippairmerging ) {
         ch_fastq_for_metagenomics = CAT_FASTQ_UNMAPPED.out.reads
-    } else if ( ( params.run_metagenomicscreening && ( params.metagenomicscreening_input == 'mapped' || params.metagenomicscreening_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
+    } else if ( ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' ) ) && params.preprocessing_skippairmerging ) {
         ch_fastq_for_metagenomics = CAT_FASTQ_UNMAPPED.out.reads
-    } else if ( params.run_metagenomicscreening && params.metagenomicscreening_input == 'unmapped' ) {
+    } else if ( params.run_metagenomics_screening && params.metagenomics_input == 'unmapped' ) {
         ch_fastq_for_metagenomics = SAMTOOLS_FASTQ_UNMAPPED.out.other
-    } else if ( params.run_metagenomicscreening && ( params.metagenomicscreening_input == 'mapped' || params.metagenomicscreening_input == 'all' )) {
+    } else if ( params.run_metagenomics_screening && ( params.metagenomics_input == 'mapped' || params.metagenomics_input == 'all' )) {
         ch_fastq_for_metagenomics = SAMTOOLS_FASTQ_MAPPED.out.other
-    } else if ( !params.run_metagenomicscreening ) {
+    } else if ( !params.run_metagenomics_screening ) {
         ch_fastq_for_metagenomics = Channel.empty()
     }
 

--- a/subworkflows/local/metagenomics.nf
+++ b/subworkflows/local/metagenomics.nf
@@ -1,0 +1,44 @@
+include { METAGENOMICS_COMPLEXITYFILTER } from './metagenomics_complexityfilter'
+include { METAGENOMICS_PROFILING        } from './metagenomics_profiling'
+
+workflow METAGENOMICS {
+    take: ch_bamfiltered_for_metagenomics
+
+    main:
+    // Define channels
+    ch_multiqc_files                = Channel.empty()
+    ch_versions                     = Channel.empty()
+    ch_bamfiltered_for_metagenomics = ch_bamfiltered_for_metagenomics
+        .map{ meta, fastq ->
+            [meta+['single_end':true], fastq]
+        }
+
+    //
+    // Run the complexity filter subworkflow
+    //
+
+    if ( params.run_metagenomics_complexityfiltering ) {
+        METAGENOMICS_COMPLEXITYFILTER( ch_bamfiltered_for_metagenomics )
+        ch_reads_for_metagenomics = METAGENOMICS_COMPLEXITYFILTER.out.fastq
+        ch_versions = ch_versions.mix(METAGENOMICS_COMPLEXITYFILTER.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(METAGENOMICS_COMPLEXITYFILTER.out.fastq.collect{it[1]}.ifEmpty([]))
+    } else {
+        ch_reads_for_metagenomics = ch_bamfiltered_for_metagenomics
+    }
+
+    //
+    // Run the profiling subworkflow
+    //
+
+    database = params.metagenomics_profiling_database
+
+    METAGENOMICS_PROFILING( ch_reads_for_metagenomics, database )
+    ch_versions      = ch_versions.mix( METAGENOMICS_PROFILING.out.versions.first() )
+    ch_multiqc_files = ch_multiqc_files.mix( METAGENOMICS_PROFILING.out.mqc.collect{it[1]}.ifEmpty([]) )
+
+    emit:
+    ch_versions      = ch_versions
+    ch_multiqc_files = ch_multiqc_files
+
+
+}

--- a/subworkflows/local/metagenomics_complexityfilter.nf
+++ b/subworkflows/local/metagenomics_complexityfilter.nf
@@ -1,0 +1,29 @@
+include { BBMAP_BBDUK                 } from '../../modules/nf-core/bbmap/bbduk/main'
+include { PRINSEQPLUSPLUS             } from '../../modules/nf-core/prinseqplusplus/main'
+
+
+workflow METAGENOMICS_COMPLEXITYFILTER {
+    take: ch_bamfiltered_for_metagenomics // [meta, fastq]
+
+    main:
+
+    //
+    // Take the selected complexity filter tool
+    //
+
+    if (params.metagenomics_complexity_tool == 'bbduk') {
+        BBMAP_BBDUK( ch_bamfiltered_for_metagenomics, [] )
+        ch_versions = BBMAP_BBDUK.out.versions.first()
+        ch_reads_for_metagenomics = BBMAP_BBDUK.out.reads
+    }
+    else if ( params.metagenomics_complexity_tool == 'prinseq' ) {
+        // check if e.g. dustscore is set but entropy enabled
+        PRINSEQPLUSPLUS ( ch_bamfiltered_for_metagenomics )
+        ch_versions = PRINSEQPLUSPLUS.out.versions.first()
+        ch_reads_for_metagenomics = PRINSEQPLUSPLUS.out.good_reads
+    }
+
+    emit:
+        fastq    = ch_reads_for_metagenomics
+        versions = ch_versions
+}

--- a/subworkflows/local/metagenomics_profiling.nf
+++ b/subworkflows/local/metagenomics_profiling.nf
@@ -1,0 +1,186 @@
+//
+// Complexity filtering and metagenomics screening of sequencing reads
+//
+
+// Much taken from nf-core/taxprofile subworkflows/local/profiling.nf
+
+include { MALT_RUN                                      } from '../../modules/nf-core/malt/run/main'
+include { KRAKEN2_KRAKEN2                               } from '../../modules/nf-core/kraken2/kraken2/main'
+include { KRAKENUNIQ_PRELOADEDKRAKENUNIQ                } from '../../modules/nf-core/krakenuniq/preloadedkrakenuniq/main'
+include { METAPHLAN3_METAPHLAN3                         } from '../../modules/nf-core/metaphlan3/metaphlan3/main'
+
+workflow METAGENOMICS_PROFILING {
+
+    take:
+    reads // channel: [ [ meta ] , [ reads ] ]
+    database // channel: [ [ meta ] , path ]
+
+    main:
+
+    ch_versions                  = Channel.empty()
+    ch_raw_classifications       = Channel.empty()
+    ch_raw_profiles              = Channel.empty()
+    ch_multiqc_files             = Channel.empty()
+    // TODO: malt, metaphylan, kraken2, krakenuniq
+    // TODO: maltextract, krakenparse
+
+    /*
+        PREPARE PROFILER INPUT CHANNELS & RUN PROFILING
+    */
+
+    // Each tool as a slightly different input structure and generally separate
+    // input channels for reads vs database. We restructure the channel tuple
+    // for each tool and make liberal use of multiMap to keep reads/database
+    // channel element order in sync with each other
+
+    if ( params.metagenomics_profiling_tool == 'malt' ) {
+
+        if ( params.metagenomics_malt_group_size > 0 ) {
+            ch_input_for_malt =  reads
+                .map {
+                    meta, reads ->
+
+                        // Reset entire input meta for MALT to just database name,
+                        // as we don't run run on a per-sample basis due to huge datbaases
+                        // so all samples are in one run and so sample-specific metadata
+                        // unnecessary. Set as database name to prevent `null` job ID and prefix.
+
+                        def temp_meta = [ id: database ]
+
+                        // Combine reduced sample metadata with updated database parameters metadata,
+                        // make sure id is db_name for publishing purposes.
+
+                        [ temp_meta, reads, database ]
+
+                }
+                .groupTuple(by: [0,2], size: params.metagenomics_malt_group_size, remainder: true)
+                .multiMap {
+                    meta, reads, database ->
+                        reads: [ meta, reads ]
+                        database: database
+                }
+        }
+
+        else {
+            ch_input_for_malt =  reads
+                .map {
+                    meta, reads ->
+
+                        // Reset entire input meta for MALT to just database name,
+                        // as we don't run run on a per-sample basis due to huge datbaases
+                        // so all samples are in one run and so sample-specific metadata
+                        // unnecessary. Set as database name to prevent `null` job ID and prefix.
+
+                        def temp_meta = [ id: database ]
+
+                        // Combine reduced sample metadata with updated database parameters metadata,
+                        // make sure id is db_name for publishing purposes.
+
+                        [ temp_meta, reads, database ]
+
+                }
+                .groupTuple(by: [0,2])
+                .multiMap {
+                    meta, reads, database ->
+                        reads: [ meta, reads ]
+                        database: database
+                }
+        }
+
+        ch_input_for_malt.reads.dump()
+        ch_input_for_malt.database.dump()
+
+        // MALT: We groupTuple to have all samples in one channel for MALT as database
+        // loading takes a long time, so we only want to run it once per database, unless otherwise specified
+
+        MALT_RUN ( ch_input_for_malt.reads, ch_input_for_malt.database )
+
+        ch_maltrun_for_megan = MALT_RUN.out.rma6
+                                .transpose()
+                                .map{
+                                    meta, rma ->
+                                            // re-extract meta from file names, use filename without rma to
+                                            // ensure we keep paired-end information in downstream filenames
+                                            // when no pair-merging
+                                            def meta_new = meta.clone()
+                                            meta_new['db_name'] = meta.id
+                                            meta_new['id'] = rma.baseName
+                                        [ meta_new, rma ]
+                                }
+
+        ch_multiqc_files       = ch_multiqc_files.mix( MALT_RUN.out.log )
+        ch_versions            = ch_versions.mix( MALT_RUN.out.versions.first() )
+        ch_raw_classifications = ch_raw_classifications.mix( ch_maltrun_for_megan )
+    }
+
+    if ( params.metagenomics_profiling_tool == 'metaphlan3' ) {
+
+        ch_input_for_metaphlan3 = ch_input_for_profiling.metaphlan3
+                            .filter{
+                                if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input. Skipping MetaPhlAn3 for sample ${it[0].id}."
+                                !it[0].is_fasta
+                            }
+                            .multiMap {
+                                it ->
+                                    reads: [it[0] + it[2], it[1]]
+                                    db: it[3]
+                            }
+
+        METAPHLAN3_METAPHLAN3 ( ch_input_for_metaphlan3.reads, database )
+        ch_versions        = ch_versions.mix( METAPHLAN3_METAPHLAN3.out.versions.first() )
+        ch_raw_profiles    = ch_raw_profiles.mix( METAPHLAN3_METAPHLAN3.out.profile )
+
+    }
+
+    if ( params.metagenomics_profiling_tool == 'krakenuniq' ) {
+        ch_input_for_krakenuniq =  ch_input_for_profiling.krakenuniq
+                                    .map {
+                                        meta, reads, db_meta, db ->
+                                            [[id: db_meta.db_name, single_end: meta.single_end], reads, db_meta, db]
+                                    }
+                                    .groupTuple(by: [0,2,3])
+                                    .multiMap {
+                                        single_meta, reads, db_meta, db ->
+                                            reads: [ single_meta + db_meta, reads.flatten() ]
+                                            db: db
+                                }
+        // Hardcode to _always_ produce the report file (which is our basic output, and goes into)
+        KRAKENUNIQ_PRELOADEDKRAKENUNIQ ( ch_input_for_krakenuniq.reads, ch_input_for_krakenuniq.db, params.metagenomics_krakenuniq_ram_chunk_size, params.metagenomics_krakenuniq_save_reads, true, params.metagenomics_krakenuniq_save_readclassifications )
+        ch_multiqc_files       = ch_multiqc_files.mix( KRAKENUNIQ_PRELOADEDKRAKENUNIQ.out.report )
+        ch_versions            = ch_versions.mix( KRAKENUNIQ_PRELOADEDKRAKENUNIQ.out.versions.first() )
+        ch_raw_classifications = ch_raw_classifications.mix( KRAKENUNIQ_PRELOADEDKRAKENUNIQ.out.classified_assignment )
+        ch_raw_profiles        = ch_raw_profiles.mix( KRAKENUNIQ_PRELOADEDKRAKENUNIQ.out.report )
+
+    }
+
+    if ( params.metagenomics_profiling_tool == 'kraken2' ) {
+        ch_input_for_kraken2 = ch_input_for_profiling.kraken2
+                                .map {
+                                    meta, reads, db_meta, db ->
+                                    [ meta, reads, db_meta, db ]
+                                }
+                                .multiMap {
+                                    it ->
+                                        reads: [ it[0] + it[2], it[1] ]
+                                        db: it[3]
+                                }
+
+        KRAKEN2_KRAKEN2 ( ch_input_for_kraken2.reads, database, params.metagenomics_kraken2_save_reads, params.metagenomics_kraken2_save_readclassification )
+        ch_multiqc_files       = ch_multiqc_files.mix( KRAKEN2_KRAKEN2.out.report )
+        ch_versions            = ch_versions.mix( KRAKEN2_KRAKEN2.out.versions.first() )
+        ch_raw_classifications = ch_raw_classifications.mix( KRAKEN2_KRAKEN2.out.classified_reads_assignment )
+        ch_raw_profiles        = ch_raw_profiles.mix(
+            KRAKEN2_KRAKEN2.out.report
+                // Set the tool to be strictly 'kraken2' instead of potentially 'bracken' for downstream use.
+                // Will remain distinct from 'pure' Kraken2 results due to distinct database names in file names.
+                .map { meta, report -> [meta + [tool: 'kraken2'], report]}
+        )
+
+    }
+
+    emit:
+    classifications   = ch_raw_classifications
+    profiles          = ch_raw_profiles    // channel: [ val(meta), [ reads ] ] - should be text files or biom
+    versions          = ch_versions          // channel: [ versions.yml ]
+    mqc               = ch_multiqc_files
+}

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -17,7 +17,12 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 // Check mandatory parameters
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
 
-// Check failing parameter combinations
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Check failing parameter combinations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
 if ( params.bamfiltering_retainunmappedgenomicbam && params.bamfiltering_mappingquality > 0  ) { exit 1, ("[nf-core/eager] ERROR: You cannot both retain unmapped reads and perform quality filtering, as unmapped reads have a mapping quality of 0. Pick one or the other functionality.") }
 if ( params.metagenomics_complexity_tool == 'prinseq' && params.metagenomics_prinseq_mode == 'dust' && params.metagenomics_complexity_entropy != 0.3 ) {
     // entropy score was set but dust method picked. If no dust-score provided, assume it was an error and fail
@@ -35,7 +40,15 @@ if ( params.metagenomics_complexity_tool == 'prinseq' && params.metagenomics_pri
 // TODO What to do when params.preprocessing_excludeunmerged is provided but the data is SE?
 if ( params.deduplication_tool == 'dedup' && ! params.preprocessing_excludeunmerged ) { exit 1, "[nf-core/eager] ERROR: Dedup can only be used on collapsed (i.e. merged) PE reads. For all other cases, please set --deduplication_tool to 'markduplicates'."}
 
-// Report possible warnings
+// TODO add any other metagenomics screening parameters checks for eg complexity filtering, post-processing
+if ( params.run_metagenomics_screening && ! params.metagenomics_profiling_database ) { exit 1, ("[nf-core/eager] ERROR: Please provide an appropriate database path for metagenomics screening") }
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Report possible warnings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
 if ( params.preprocessing_skipadaptertrim && params.preprocessing_adapterlist ) log.warn("[nf-core/eager] --preprocessing_skipadaptertrim will override --preprocessing_adapterlist. Adapter trimming will be skipped!")
 
 /*
@@ -67,6 +80,7 @@ include { MAP                           } from '../subworkflows/local/map'
 include { FILTER_BAM                    } from '../subworkflows/local/bamfiltering.nf'
 include { DEDUPLICATE                   } from '../subworkflows/local/deduplicate'
 include { METAGENOMICS_COMPLEXITYFILTER } from '../subworkflows/local/metagenomics_complexityfilter'
+include { METAGENOMICS_PROFILING        } from '../subworkflows/local/metagenomics_profiling'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -189,7 +203,7 @@ workflow EAGER {
     // SUBWORKFLOW: bam filtering (length, mapped/unmapped, quality etc.)
     //
 
-    if ( params.run_bamfiltering || params.run_metagenomicscreening ) {
+    if ( params.run_bamfiltering || params.run_metagenomics_screening ) {
 
         ch_mapped_for_bamfilter = MAP.out.bam
                                     .join(MAP.out.bai)
@@ -282,6 +296,13 @@ workflow EAGER {
         ch_multiqc_files = ch_multiqc_files.mix(PRESEQ_LCEXTRAP.out.lc_extrap.collect{it[1]}.ifEmpty([]))
         ch_versions = ch_versions.mix( PRESEQ_LCEXTRAP.out.versions )
     }
+    // SUBWORKFLOW: metagenomics screening
+    //
+    //TODO: finish and figure out how exactly to call with proper database (check via a helper function?)
+    if ( params.run_metagenomics_screening ) {
+        METAGENOMICS_PROFILING ( ch_bamfiltered_for_metagenomics, params.metagenomics_profiling_database ) // TODO: implement full metagenomics screening main subworkflow
+    }
+    // that then calls complexityfilter, profiling, postprocessing
 
     //
     // MODULE: MultiQC

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -71,6 +71,8 @@ include { SAMTOOLS_INDEX              } from '../modules/nf-core/samtools/index/
 include { PRESEQ_CCURVE               } from '../modules/nf-core/preseq/ccurve/main'
 include { PRESEQ_LCEXTRAP             } from '../modules/nf-core/preseq/lcextrap/main'
 include { FALCO                       } from '../modules/nf-core/falco/main'
+include { MTNUCRATIO                  } from '../modules/nf-core/mtnucratio/main'
+
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,6 +220,21 @@ workflow EAGER {
     }
 
     //
+    // MODULE: MTNUCRATIO
+    //
+    if ( params.run_mtnucratio ) {
+        mtnucratio_input = ch_dedupped_bams
+        .map {
+            meta, bam, bai ->
+            [ meta, bam ]
+        }
+
+        MTNUCRATIO( mtnucratio_input, params.mitochondrion_header )
+        ch_multiqc_files = ch_multiqc_files.mix(MTNUCRATIO.out.mtnucratio.collect{it[1]}.ifEmpty([]))
+        ch_versions      = ch_versions.mix( MTNUCRATIO.out.versions )
+    }
+
+    //
     // MODULE: PreSeq
     //
     if ( !params.mapstats_skip_preseq && params.mapstats_preseq_mode == 'c_curve') {
@@ -247,6 +264,7 @@ workflow EAGER {
     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
+    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
 
     MULTIQC (
         ch_multiqc_files.collect(),

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -41,7 +41,7 @@ if ( params.metagenomics_complexity_tool == 'prinseq' && params.metagenomics_pri
 if ( params.deduplication_tool == 'dedup' && ! params.preprocessing_excludeunmerged ) { exit 1, "[nf-core/eager] ERROR: Dedup can only be used on collapsed (i.e. merged) PE reads. For all other cases, please set --deduplication_tool to 'markduplicates'."}
 
 // TODO add any other metagenomics screening parameters checks for eg complexity filtering, post-processing
-if ( params.run_metagenomics_screening && ! params.metagenomics_profiling_database ) { exit 1, ("[nf-core/eager] ERROR: Please provide an appropriate database path for metagenomics screening using --metagenomics_profiling_database") }
+if ( params.run_metagenomics && ! params.metagenomics_profiling_database ) { exit 1, ("[nf-core/eager] ERROR: Please provide an appropriate database path for metagenomics screening using --metagenomics_profiling_database") }
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -203,7 +203,7 @@ workflow EAGER {
     // SUBWORKFLOW: bam filtering (length, mapped/unmapped, quality etc.)
     //
 
-    if ( params.run_bamfiltering || params.run_metagenomics_screening ) {
+    if ( params.run_bamfiltering || params.run_metagenomics ) {
 
         ch_mapped_for_bamfilter = MAP.out.bam
                                     .join(MAP.out.bai)
@@ -299,7 +299,7 @@ workflow EAGER {
     // SUBWORKFLOW: metagenomics screening
     //
     //TODO: finish and figure out how exactly to call with proper database (check via a helper function?)
-    if ( params.run_metagenomics_screening ) {
+    if ( params.run_metagenomics ) {
         METAGENOMICS_PROFILING ( ch_bamfiltered_for_metagenomics, params.metagenomics_profiling_database ) // TODO: implement full metagenomics screening main subworkflow
     }
     // that then calls complexityfilter, profiling, postprocessing

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -19,6 +19,18 @@ if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input sample
 
 // Check failing parameter combinations
 if ( params.bamfiltering_retainunmappedgenomicbam && params.bamfiltering_mappingquality > 0  ) { exit 1, ("[nf-core/eager] ERROR: You cannot both retain unmapped reads and perform quality filtering, as unmapped reads have a mapping quality of 0. Pick one or the other functionality.") }
+if ( params.metagenomics_complexity_tool == 'prinseq' && params.metagenomics_prinseq_mode == 'dust' && params.metagenomics_complexity_entropy != 0.3 ) {
+    // entropy score was set but dust method picked. If no dust-score provided, assume it was an error and fail
+    if (params.metagenomics_prinseq_dustscore == 0.5) {
+            exit 1, ("[nf-core/eager] ERROR: Metagenomics: You picked PRINSEQ++ with 'dust' mode but provided an entropy score. Please specify a dust filter threshold using the --metagenomics_prinseq_dustscore flag")
+    }
+}
+if ( params.metagenomics_complexity_tool == 'prinseq' && params.metagenomics_prinseq_mode == 'entropy' && params.metagenomics_prinseq_dustscore != 0.5 ) {
+    // dust score was set but entropy method picked. If no entropy-score provided, assume it was an error and fail
+    if (params.metagenomics_complexity_entropy == 0.3) {
+            exit 1, ("[nf-core/eager] ERROR: Metagenomics: You picked PRINSEQ++ with 'entropy' mode but provided a dust score. Please specify an entropy filter threshold using the --metagenomics_complexity_entropy flag")
+    }
+}
 
 // TODO What to do when params.preprocessing_excludeunmerged is provided but the data is SE?
 if ( params.deduplication_tool == 'dedup' && ! params.preprocessing_excludeunmerged ) { exit 1, "[nf-core/eager] ERROR: Dedup can only be used on collapsed (i.e. merged) PE reads. For all other cases, please set --deduplication_tool to 'markduplicates'."}
@@ -48,12 +60,13 @@ ch_multiqc_custom_methods_description = params.multiqc_methods_description ? fil
 //
 
 // TODO rename to active: index_reference, filter_bam etc.
-include { INPUT_CHECK        } from '../subworkflows/local/input_check'
-include { REFERENCE_INDEXING } from '../subworkflows/local/reference_indexing'
-include { PREPROCESSING      } from '../subworkflows/local/preprocessing'
-include { MAP                } from '../subworkflows/local/map'
-include { FILTER_BAM         } from '../subworkflows/local/bamfiltering.nf'
-include { DEDUPLICATE        } from '../subworkflows/local/deduplicate'
+include { INPUT_CHECK                   } from '../subworkflows/local/input_check'
+include { REFERENCE_INDEXING            } from '../subworkflows/local/reference_indexing'
+include { PREPROCESSING                 } from '../subworkflows/local/preprocessing'
+include { MAP                           } from '../subworkflows/local/map'
+include { FILTER_BAM                    } from '../subworkflows/local/bamfiltering.nf'
+include { DEDUPLICATE                   } from '../subworkflows/local/deduplicate'
+include { METAGENOMICS_COMPLEXITYFILTER } from '../subworkflows/local/metagenomics_complexityfilter'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -220,8 +233,30 @@ workflow EAGER {
     }
 
     //
+    // Section: Metagenomics screening
+    //
+
+    if( params.run_metagenomicscreening ) {
+        ch_bamfiltered_for_metagenomics = ch_bamfiltered_for_metagenomics
+            .map{ meta, fastq ->
+                [meta+['single_end':true], fastq]
+            }
+
+        // Check if a complexity filter is wanted?
+        if ( params.run_metagenomics_complexityfiltering ) {
+            METAGENOMICS_COMPLEXITYFILTER( ch_bamfiltered_for_metagenomics )
+            ch_reads_for_metagenomics = METAGENOMICS_COMPLEXITYFILTER.out.fastq
+            ch_versions = ch_versions.mix(METAGENOMICS_COMPLEXITYFILTER.out.versions.first())
+            ch_multiqc_files = ch_multiqc_files.mix(METAGENOMICS_COMPLEXITYFILTER.out.fastq.collect{it[1]}.ifEmpty([]))
+        } else {
+            ch_reads_for_metagenomics = ch_bamfiltered_for_metagenomics
+        }
+    }
+
+    //
     // MODULE: MTNUCRATIO
     //
+
     if ( params.run_mtnucratio ) {
         mtnucratio_input = ch_dedupped_bams
         .map {
@@ -237,6 +272,7 @@ workflow EAGER {
     //
     // MODULE: PreSeq
     //
+
     if ( !params.mapstats_skip_preseq && params.mapstats_preseq_mode == 'c_curve') {
         PRESEQ_CCURVE(ch_reads_for_deduplication.map{[it[0],it[1]]})
         ch_multiqc_files = ch_multiqc_files.mix(PRESEQ_CCURVE.out.c_curve.collect{it[1]}.ifEmpty([]))

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -41,7 +41,7 @@ if ( params.metagenomics_complexity_tool == 'prinseq' && params.metagenomics_pri
 if ( params.deduplication_tool == 'dedup' && ! params.preprocessing_excludeunmerged ) { exit 1, "[nf-core/eager] ERROR: Dedup can only be used on collapsed (i.e. merged) PE reads. For all other cases, please set --deduplication_tool to 'markduplicates'."}
 
 // TODO add any other metagenomics screening parameters checks for eg complexity filtering, post-processing
-if ( params.run_metagenomics_screening && ! params.metagenomics_profiling_database ) { exit 1, ("[nf-core/eager] ERROR: Please provide an appropriate database path for metagenomics screening") }
+if ( params.run_metagenomics_screening && ! params.metagenomics_profiling_database ) { exit 1, ("[nf-core/eager] ERROR: Please provide an appropriate database path for metagenomics screening using --metagenomics_profiling_database") }
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Implementation of dsl2 subworkflow (eventually will be implemented as subworkflow of subworkflow, along with #960 and post-processing.

Added functionality: grouping of malt inputs (!!) for parallelized submits across an arbitrary number of fastq files (implementation for outputting needs to be tested/revised)

Also need to figure out which optional parameters for metaphlan2, kraken2, krakenuniq should be included as parameters in nextflow.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
