### PR TITLE
2.4.7 Patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
 
       - name: Build new docker image
         if: env.MATCHED_FILES
-        run: docker build --no-cache . -t nfcore/eager:2.4.6
+        run: docker build --no-cache . -t nfcore/eager:2.4.7
 
       - name: Pull docker image
         if: ${{ !env.MATCHED_FILES }}
         run: |
           docker pull nfcore/eager:dev
-          docker tag nfcore/eager:dev nfcore/eager:2.4.6
+          docker tag nfcore/eager:dev nfcore/eager:2.4.7
 
       - name: Install Nextflow
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['20.07.1', '']
+        nxf_ver: ['20.07.1', '22.10.6']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.4.7dev] - 
+## [2.4.7] - 2023-05-16
 
 ### `Added`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.4.7] - 2023-05-16
+
+### `Fixed`
+
+- [#983](https://github.com/nf-core/eager/issues/983) Bump `pygments` version due to incompatibility with MultiQC dependencies (♥ to @MinLuke for reporting)
+
 ## [2.4.6] - 2022-11-14
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,19 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.4.7] - 2023-05-16
+## [2.4.7dev] - 
+
+### `Added`
 
 ### `Fixed`
 
 - [#983](https://github.com/nf-core/eager/issues/983) Bump `pygments` version due to incompatibility with MultiQC dependencies (♥ to @MinLuke for reporting)
+
+### `Dependencies`
+
+- `pygments`: 2.9 -> 2.14
+
+### `Deprecated`
 
 ## [2.4.6] - 2022-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Dependencies`
 
 - `pygments`: 2.9 -> 2.14
+- `multiqc`: 1.13 -> 1.14
 
 ### `Deprecated`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY environment.yml /
 RUN conda env create --quiet -f /environment.yml && conda clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/nf-core-eager-2.4.6/bin:$PATH
+ENV PATH /opt/conda/envs/nf-core-eager-2.4.7/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name nf-core-eager-2.4.6 > nf-core-eager-2.4.6.yml
+RUN conda env export --name nf-core-eager-2.4.7 > nf-core-eager-2.4.7.yml

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - bioconda::qualimap=2.2.2d
   - bioconda::vcf2genome=0.91
   - bioconda::damageprofiler=0.4.9 # Don't upgrade - later versions don't allow java 8
-  - bioconda::multiqc=1.13
+  - bioconda::multiqc=1.14
   - bioconda::pmdtools=0.60
   - bioconda::bedtools=2.30.0
   - conda-forge::libiconv=1.16

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - conda-forge::python=3.9.4
   - conda-forge::markdown=3.3.4
   - conda-forge::pymdown-extensions=8.2
-  - conda-forge::pygments=2.9.0
+  - conda-forge::pygments=2.14.0
   - bioconda::rename=1.601
   - conda-forge::openjdk=8.0.144 # Don't upgrade - required for GATK
   - bioconda::fastqc=0.11.9

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: nf-core-eager-2.4.6
+name: nf-core-eager-2.4.7
 channels:
   - conda-forge
   - bioconda

--- a/nextflow.config
+++ b/nextflow.config
@@ -285,7 +285,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'nfcore/eager:2.4.6'
+process.container = 'nfcore/eager:2.4.7'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -415,7 +415,7 @@ manifest {
   description = 'A fully reproducible and state-of-the-art ancient DNA analysis pipeline'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.07.1'
-  version = '2.4.6'
+  version = '2.4.7'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
Closes https://github.com/nf-core/eager/issues/983 and a broken conda environment

Tested by manually editing environment to bump the pygments to the minimal version as reported in teh error, and then linted with nf-core tools 1.9

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
