### PR TITLE
DSL2: adapt test_humanbam profile

### DIFF
--- a/conf/test_humanbam.config
+++ b/conf/test_humanbam.config
@@ -25,7 +25,11 @@ params {
     input = 'https://raw.githubusercontent.com/nf-core/test-datasets/eager/testdata/Human/human_design_bam_eager3.tsv'
 
     // Genome references
-    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/eager/reference/Human/hs37d5_chr21.fasta'
+    fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/eager/reference/Human/hs37d5_chr21-MT.fa.gz'
+
+    // Contamination estimation
+    contamination_estimation_angsd_mapq = 0
+    contamination_estimation_angsd_minq = 0
 
     // TODO Reactivate sexDet and genotyping params when those steps get implemented.
     // //Sex Determination


### PR DESCRIPTION
Added larger human reference fasta and angsd parameters to the test_humanbam profile

<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
