### PR TITLE
DSL2: add reference masking for PMDtools

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -232,8 +232,9 @@ process {
     }
 
     withName: 'GUNZIP_PMDFASTA|GUNZIP_PMDSNP|GUNZIP_SNPBED' {
-        publishDir:
+        publishDir = [
             enabled: false
+        ]
     }
 
     withName: SAMTOOLS_FAIDX {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -231,6 +231,11 @@ process {
         ]
     }
 
+    withName: 'GUNZIP_PMDFASTA|GUNZIP_PMDSNP|GUNZIP_SNPBED' {
+        publishDir:
+            enabled: false
+    }
+
     withName: SAMTOOLS_FAIDX {
         publishDir = [
             path: { "${params.outdir}/reference/${meta.id}/" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -662,6 +662,16 @@ process {
     //
     // DAMAGE MANIPULATION
     //
+
+    withName: BEDTOOLS_MASKFASTA {
+        ext.prefix = { "${meta.id}.masked" }
+        publishDir = [
+            path: { "${params.outdir}/damage_manipulation/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.masked.fa'
+        ]
+    }
+
     withName: MAPDAMAGE2 {
         tag = { "${meta.reference}|${meta.sample_id}_${meta.library_id}" }
         ext.args = { [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -666,7 +666,7 @@ process {
     withName: BEDTOOLS_MASKFASTA {
         ext.prefix = { "${meta.id}.masked" }
         publishDir = [
-            path: { "${params.outdir}/damage_manipulation/" },
+            path: { "${params.outdir}/reference/masked_reference/" },
             mode: params.publish_dir_mode,
             pattern: '*.masked.fa'
         ]

--- a/docs/development/dev_docs.md
+++ b/docs/development/dev_docs.md
@@ -1,0 +1,40 @@
+# Documentation and how tos for developing eager
+
+## How to add new input files and options to the reference sheet
+To add new input files or option to the reference sheet, you have to complete all the following steps.
+
+### Single-reference input workflow
+1. Add your new parameter to nextflow.config.
+2. Add parameter description to schema (nf-core schema build).
+3. Read in new parameter (params.NEW) as input within the reference_indexing_single local subworkflow.
+  1. Add new line to the large .map{} operation starting on line 80 and add check if the file exists.
+    ```def PARAM_NAME = params.NEW != null ? file(params.NEW, checkIfExists: true ) : ""```
+  2. Add PARAM_NAME to the result of the map operation. Double-check the order!
+  3. With the ch_ref_index_single.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
+    ```NEW_SUBCHANNEL: [ meta, PARAM_NAME ]```
+  4. Add your ch_ref_index_single.NEW_SUBCHANNEL to the final emit.
+    ```NEW_EMIT = ch_ref_index_single.NEW_SUBCHANNEL```
+
+### Multi-reference input workflow
+1. Add new column named SOFTWARE_FILETYPE and test data to the test reference sheet (https://github.com/nf-core/test-datasets/blob/eager/reference/reference_sheet_multiref.csv).
+2. Read in new input within the reference_indexing_multi local subworkflow.
+  1. Add new line to the large .map{} operation starting on line 30. Add check if the file exists if appropriate.
+    ```def PARAM_NAME = row["SOFTWARE_FILETYPE"] != "" ? file(row["SOFTWARE_FILETYPE"], checkIfExists: true) : ""```
+  2. Add PARAM_NAME to the result of the map operation. Double-check the order!
+  3. With the ch_input_from_referencesheet.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
+    ```NEW_SUBCHANNEL: [ meta, PARAM_NAME ]```
+  4. Add ch_input_from_referencesheet.NEW_SUBCHANNEL to the final emit.
+    ```NEW_EMIT = ch_input_from_referencesheet.NEW_SUBCHANNEL```
+
+### Combining in the Reference Indexing workflow
+1. Add you new parameter channel to the if condition selecting between the direct parameter input or the reference sheet input.
+  1. below line 25 for reference sheet input
+    ```ch_NEW_CHANNEL = REFERENCE_INDEXING_MULTI.out.NEW_EMIT```
+  2. below "REFERENCE_INDEXING_SINGLE"
+    ```ch_NEW_CHANNEL = REFERENCE_INDEXING_SINGLE.out.NEW_EMIT```
+2. Filter out options that have not been provided.
+  ```ch_NEW_CHANNEL = ch_NEW_CHANNEL.filter{ it[1] != "" }```
+3. Add unzipping of zipped input files with GUNZIP.
+4. Add ch_NEW_CHANNEL to the final emit.
+    ```NEW_EMIT = ch_NEW_CHANNEL```
+5. Call new inputs within the main eager.nf with ```REFERENCE_INDEXING.out.NEW_EMIT```.

--- a/docs/development/dev_docs.md
+++ b/docs/development/dev_docs.md
@@ -33,12 +33,12 @@ To add new input files or options to the reference sheet, you have to complete a
 
 1. Add you new parameter channel to the `if` condition selecting between the direct parameter input or the reference sheet input.
    1. below "REFERENCE_INDEXING_MULTI" for reference sheet input
-      `ch_<NEW_CHANNEL> = REFERENCE_INDEXING_MULTI.out.<NEW_EMIT>`
+      `<NEW_CHANNEL> = REFERENCE_INDEXING_MULTI.out.<NEW_EMIT>`
    2. below "REFERENCE_INDEXING_SINGLE"
-      `ch_<NEW_CHANNEL> = REFERENCE_INDEXING_SINGLE.out.<NEW_EMIT>`
+      `<NEW_CHANNEL> = REFERENCE_INDEXING_SINGLE.out.<NEW_EMIT>`
    3. Filter out options that have not been provided.
-      `ch_<NEW_CHANNEL> = ch_<NEW_CHANNEL>.filter{ it[1] != "" }`
+      `<NEW_CHANNEL> = <NEW_CHANNEL>.filter{ it[1] != "" }`
    4. Add unzipping of zipped input files with GUNZIP.
-   5. Add ch_<NEW_CHANNEL> to the final emit.
-      `<NEW_EMIT> = ch_<NEW_CHANNEL>`
+   5. Add <NEW_CHANNEL> to the final emit.
+      `<NEW_EMIT> = <NEW_CHANNEL>`
    6. Call new inputs within the main eager.nf with `REFERENCE_INDEXING.out.<NEW_EMIT>`.

--- a/docs/development/dev_docs.md
+++ b/docs/development/dev_docs.md
@@ -1,40 +1,44 @@
 # Documentation and how tos for developing eager
 
 ## How to add new input files and options to the reference sheet
+
 To add new input files or option to the reference sheet, you have to complete all the following steps.
 
 ### Single-reference input workflow
+
 1. Add your new parameter to nextflow.config.
 2. Add parameter description to schema (nf-core schema build).
 3. Read in new parameter (params.NEW) as input within the reference_indexing_single local subworkflow.
-  1. Add new line to the large .map{} operation starting on line 80 and add check if the file exists.
-    ```def PARAM_NAME = params.NEW != null ? file(params.NEW, checkIfExists: true ) : ""```
-  2. Add PARAM_NAME to the result of the map operation. Double-check the order!
-  3. With the ch_ref_index_single.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
-    ```NEW_SUBCHANNEL: [ meta, PARAM_NAME ]```
-  4. Add your ch_ref_index_single.NEW_SUBCHANNEL to the final emit.
-    ```NEW_EMIT = ch_ref_index_single.NEW_SUBCHANNEL```
+   1. Add new line to the large .map{} operation starting on line 80 and add check if the file exists.
+      `def PARAM_NAME = params.NEW != null ? file(params.NEW, checkIfExists: true ) : ""`
+   2. Add PARAM_NAME to the result of the map operation. Double-check the order!
+   3. With the ch_ref_index_single.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
+      `NEW_SUBCHANNEL: [ meta, PARAM_NAME ]`
+   4. Add your ch_ref_index_single.NEW_SUBCHANNEL to the final emit.
+      `NEW_EMIT = ch_ref_index_single.NEW_SUBCHANNEL`
 
 ### Multi-reference input workflow
+
 1. Add new column named SOFTWARE_FILETYPE and test data to the test reference sheet (https://github.com/nf-core/test-datasets/blob/eager/reference/reference_sheet_multiref.csv).
 2. Read in new input within the reference_indexing_multi local subworkflow.
-  1. Add new line to the large .map{} operation starting on line 30. Add check if the file exists if appropriate.
-    ```def PARAM_NAME = row["SOFTWARE_FILETYPE"] != "" ? file(row["SOFTWARE_FILETYPE"], checkIfExists: true) : ""```
-  2. Add PARAM_NAME to the result of the map operation. Double-check the order!
-  3. With the ch_input_from_referencesheet.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
-    ```NEW_SUBCHANNEL: [ meta, PARAM_NAME ]```
-  4. Add ch_input_from_referencesheet.NEW_SUBCHANNEL to the final emit.
-    ```NEW_EMIT = ch_input_from_referencesheet.NEW_SUBCHANNEL```
+   1. Add new line to the large .map{} operation starting on line 30. Add check if the file exists if appropriate.
+      `def PARAM_NAME = row["SOFTWARE_FILETYPE"] != "" ? file(row["SOFTWARE_FILETYPE"], checkIfExists: true) : ""`
+   2. Add PARAM_NAME to the result of the map operation. Double-check the order!
+   3. With the ch_input_from_referencesheet.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
+      `NEW_SUBCHANNEL: [ meta, PARAM_NAME ]`
+   4. Add ch_input_from_referencesheet.NEW_SUBCHANNEL to the final emit.
+      `NEW_EMIT = ch_input_from_referencesheet.NEW_SUBCHANNEL`
 
 ### Combining in the Reference Indexing workflow
+
 1. Add you new parameter channel to the if condition selecting between the direct parameter input or the reference sheet input.
-  1. below line 25 for reference sheet input
-    ```ch_NEW_CHANNEL = REFERENCE_INDEXING_MULTI.out.NEW_EMIT```
-  2. below "REFERENCE_INDEXING_SINGLE"
-    ```ch_NEW_CHANNEL = REFERENCE_INDEXING_SINGLE.out.NEW_EMIT```
-2. Filter out options that have not been provided.
-  ```ch_NEW_CHANNEL = ch_NEW_CHANNEL.filter{ it[1] != "" }```
-3. Add unzipping of zipped input files with GUNZIP.
-4. Add ch_NEW_CHANNEL to the final emit.
-    ```NEW_EMIT = ch_NEW_CHANNEL```
-5. Call new inputs within the main eager.nf with ```REFERENCE_INDEXING.out.NEW_EMIT```.
+   1. below line 25 for reference sheet input
+      `ch_NEW_CHANNEL = REFERENCE_INDEXING_MULTI.out.NEW_EMIT`
+   2. below "REFERENCE_INDEXING_SINGLE"
+      `ch_NEW_CHANNEL = REFERENCE_INDEXING_SINGLE.out.NEW_EMIT`
+   3. Filter out options that have not been provided.
+      `ch_NEW_CHANNEL = ch_NEW_CHANNEL.filter{ it[1] != "" }`
+   4. Add unzipping of zipped input files with GUNZIP.
+   5. Add ch_NEW_CHANNEL to the final emit.
+      `NEW_EMIT = ch_NEW_CHANNEL`
+   6. Call new inputs within the main eager.nf with `REFERENCE_INDEXING.out.NEW_EMIT`.

--- a/docs/development/dev_docs.md
+++ b/docs/development/dev_docs.md
@@ -2,43 +2,43 @@
 
 ## How to add new input files and options to the reference sheet
 
-To add new input files or option to the reference sheet, you have to complete all the following steps.
+To add new input files or options to the reference sheet, you have to complete all the following steps.
 
 ### Single-reference input workflow
 
 1. Add your new parameter to nextflow.config.
 2. Add parameter description to schema (nf-core schema build).
-3. Read in new parameter (params.NEW) as input within the reference_indexing_single local subworkflow.
-   1. Add new line to the large .map{} operation starting on line 80 and add check if the file exists.
-      `def PARAM_NAME = params.NEW != null ? file(params.NEW, checkIfExists: true ) : ""`
-   2. Add PARAM_NAME to the result of the map operation. Double-check the order!
-   3. With the ch_ref_index_single.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
-      `NEW_SUBCHANNEL: [ meta, PARAM_NAME ]`
-   4. Add your ch_ref_index_single.NEW_SUBCHANNEL to the final emit.
-      `NEW_EMIT = ch_ref_index_single.NEW_SUBCHANNEL`
+3. Read in new parameter (params.<NEW>) as input within the reference_indexing_single local subworkflow.
+   1. Add new line to the large `.map{}` operation starting on [line 80(https://github.com/nf-core/eager/blob/d4211582f349cc30c88202c12942218f99006041/subworkflows/local/reference_indexing_single.nf#L80)] and add check if the file exists.
+      `def <PARAM_NAME> = params.<NEW> != null ? file(params.<NEW>, checkIfExists: true ) : ""`
+   2. Add <PARAM_NAME> to the result of the map operation. Double-check the order!
+   3. With the `ch_ref_index_single.multiMap{}` below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
+      `<NEW_SUBCHANNE>: [ meta, <PARAM_NAME> ]`
+   4. Add your ch_ref_index_single.<NEW_SUBCHANNEL> to the final emit.
+      `<NEW_EMIT> = ch_ref_index_single.<NEW_SUBCHANNEL>`
 
 ### Multi-reference input workflow
 
-1. Add new column named SOFTWARE_FILETYPE and test data to the test reference sheet (https://github.com/nf-core/test-datasets/blob/eager/reference/reference_sheet_multiref.csv).
+1. Add new column named <SOFTWARE_FILETYPE> and test data to the test reference sheet (https://github.com/nf-core/test-datasets/blob/eager/reference/reference_sheet_multiref.csv).
 2. Read in new input within the reference_indexing_multi local subworkflow.
-   1. Add new line to the large .map{} operation starting on line 30. Add check if the file exists if appropriate.
-      `def PARAM_NAME = row["SOFTWARE_FILETYPE"] != "" ? file(row["SOFTWARE_FILETYPE"], checkIfExists: true) : ""`
-   2. Add PARAM_NAME to the result of the map operation. Double-check the order!
-   3. With the ch_input_from_referencesheet.multiMap{} below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
-      `NEW_SUBCHANNEL: [ meta, PARAM_NAME ]`
-   4. Add ch_input_from_referencesheet.NEW_SUBCHANNEL to the final emit.
-      `NEW_EMIT = ch_input_from_referencesheet.NEW_SUBCHANNEL`
+   1. Add new line to the large `.map{}` operation starting on [line 30](https://github.com/nf-core/eager/blob/d4211582f349cc30c88202c12942218f99006041/subworkflows/local/reference_indexing_multi.nf#L30). Add check if the file exists if appropriate.
+      `def <PARAM_NAME> = row["<SOFTWARE_FILETYPE>"] != "" ? file(row["<SOFTWARE_FILETYPE>"], checkIfExists: true) : ""`
+   2. Add <PARAM_NAME> to the result of the `.map{}` operation. Double-check the order!
+   3. With the `ch_input_from_referencesheet.multiMap{}` below you add the reference name as a meta. You can also combine your new parameter with others if useful for the workflow step.
+      `<NEW_SUBCHANNEL>: [ meta, <PARAM_NAME> ]`
+   4. Add ch_input_from_referencesheet.<NEW_SUBCHANNEL> to the final emit.
+      `<NEW_EMIT> = ch_input_from_referencesheet.<NEW_SUBCHANNEL>`
 
 ### Combining in the Reference Indexing workflow
 
-1. Add you new parameter channel to the if condition selecting between the direct parameter input or the reference sheet input.
-   1. below line 25 for reference sheet input
-      `ch_NEW_CHANNEL = REFERENCE_INDEXING_MULTI.out.NEW_EMIT`
+1. Add you new parameter channel to the `if` condition selecting between the direct parameter input or the reference sheet input.
+   1. below "REFERENCE_INDEXING_MULTI" for reference sheet input
+      `ch_<NEW_CHANNEL> = REFERENCE_INDEXING_MULTI.out.<NEW_EMIT>`
    2. below "REFERENCE_INDEXING_SINGLE"
-      `ch_NEW_CHANNEL = REFERENCE_INDEXING_SINGLE.out.NEW_EMIT`
+      `ch_<NEW_CHANNEL> = REFERENCE_INDEXING_SINGLE.out.<NEW_EMIT>`
    3. Filter out options that have not been provided.
-      `ch_NEW_CHANNEL = ch_NEW_CHANNEL.filter{ it[1] != "" }`
+      `ch_<NEW_CHANNEL> = ch_<NEW_CHANNEL>.filter{ it[1] != "" }`
    4. Add unzipping of zipped input files with GUNZIP.
-   5. Add ch_NEW_CHANNEL to the final emit.
-      `NEW_EMIT = ch_NEW_CHANNEL`
-   6. Call new inputs within the main eager.nf with `REFERENCE_INDEXING.out.NEW_EMIT`.
+   5. Add ch_<NEW_CHANNEL> to the final emit.
+      `<NEW_EMIT> = ch_<NEW_CHANNEL>`
+   6. Call new inputs within the main eager.nf with `REFERENCE_INDEXING.out.<NEW_EMIT>`.

--- a/docs/development/manual_tests.md
+++ b/docs/development/manual_tests.md
@@ -92,6 +92,8 @@ Tool Specific combinations
 
     - with default parameters
     - with stricter threshold
+    - with fasta masking
+    - with fasta masking for 1 of 2 references
 
   - BAM trimming
 
@@ -613,6 +615,18 @@ nextflow run . -profile test,docker --run_pmd_filtering -resume --outdir ./resul
 # JK2782_JK2782_TGGCCGATCAACGA_BAM_pmdfiltered.bam:  64
 # JK2782_JK2782_TGGCCGATCAACGA_pmdfiltered.bam:      137
 # JK2802_JK2802_AGAATAACCTACCA_pmdfiltered.bam:      30
+```
+
+```bash
+## PMD filtering with fasta masking
+## Expect: damage_manipulation directory with *.masked.fa and bam and bai and flagstat per library
+nextflow run . -profile test_humanbam,docker --run_pmd_filtering --damage_manipulation_pmdtools_reference_mask https://raw.githubusercontent.com/nf-core/test-datasets/eager/reference/Human/1240K.pos.list_hs37d5.0based.bed.gz -resume --outdir ./results
+```
+
+```bash
+## PMD filtering with fasta masking for 1 of 2 references
+## Expect: damage_manipulation directory with hs37d5_chr21-MT.masked.fa and bam and bai and flagstat per library and reference (22 files total). hs37d5_chr21-MT first masked with 1240K.pos.list_hs37d5.0based.bed.gz from reference sheet, PMD filtering run with masked reference fasta for hs37d5 and non-masked reference fasta for Mammoth_MT
+nextflow run . -profile test_multiref,docker --run_pmd_filtering --outdir ./results
 ```
 
 ## BAM trimming

--- a/docs/output.md
+++ b/docs/output.md
@@ -465,13 +465,12 @@ Be advised that this process introduces reference bias in the resulting rescaled
   - `*_pmdfiltered.bam`: Reads aligned to a reference genome that pass the post-mortem-damage threshold, in BAM format.
   - `*_pmdfiltered.bam.{bai,csi}`: Index file corresponding to the BAM file.
   - `*_pmdfiltered.flagstat`: Statistics of aligned reads after from SAMtools `flagstat`, after filtering for post-mortem damage.
-  - `*.masked.fa`: _Only present if a BED file has been supplied with `--damage_manipulation_pmdtools_reference_mask` or within a reference sheet._ Reference FASTA file with positions from the BED file masked with BEDTools `maskfasta`.
 
 </details>
 
 [pmdtools](https://github.com/pontussk/PMDtools) implements a likelihood framework incorporating a postmortem damage (PMD) score, base quality scores and biological polymorphism to identify degraded DNA sequences that are unlikely to originate from modern contamination. Using the model, each sequence is assigned a PMD score, for which positive values indicate support for the sequence being genuinely ancient.
 By filtering a BAM file for damaged reads in this way, it is possible to ameliorate the effects of present-day contamination, and isolate sequences of likely ancient origin to be used downstream.
-By default, all positions are assessed for damage, but it is possible to provide a FASTA file masked for specific references (`--damage_manipulation_pmdtools_masked_reference`) or a BED file to mask the reference FASTA within nf-core/eager (`--damage_manipulation_pmdtools_reference_mask`). This can alleviate reference by when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.
+By default, all positions are assessed for damage, but it is possible to provide a FASTA file masked for specific references (`--damage_manipulation_pmdtools_masked_reference`) or a BED file to mask the reference FASTA within nf-core/eager (`--damage_manipulation_pmdtools_reference_mask`). This can alleviate reference bias when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.
 
 ### Base Trimming
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -464,11 +464,14 @@ Be advised that this process introduces reference bias in the resulting rescaled
 
   - `*_pmdfiltered.bam`: Reads aligned to a reference genome that pass the post-mortem-damage threshold, in BAM format.
   - `*_pmdfiltered.bam.{bai,csi}`: Index file corresponding to the BAM file.
+  - `*_pmdfiltered.flagstat`: Statistics of aligned reads after from SAMtools `flagstat`, after filtering for post-mortem damage.
+  - `*.masked.fa`: _Only present if a BED file has been supplied with `--damage_manipulation_pmdtools_reference_mask` or within a reference sheet._ Reference FASTA file with positions from the BED file masked with BEDTools `maskfasta`.
 
 </details>
 
 [pmdtools](https://github.com/pontussk/PMDtools) implements a likelihood framework incorporating a postmortem damage (PMD) score, base quality scores and biological polymorphism to identify degraded DNA sequences that are unlikely to originate from modern contamination. Using the model, each sequence is assigned a PMD score, for which positive values indicate support for the sequence being genuinely ancient.
 By filtering a BAM file for damaged reads in this way, it is possible to ameliorate the effects of present-day contamination, and isolate sequences of likely ancient origin to be used downstream.
+By default, all positions are assessed for damage, but it is possible to provide a FASTA file masked for specific references (`--damage_manipulation_pmdtools_masked_reference`) or a BED file to mask the reference FASTA within nf-core/eager (`--damage_manipulation_pmdtools_reference_mask`). This can alleviate reference by when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.
 
 ### Base Trimming
 

--- a/modules.json
+++ b/modules.json
@@ -35,6 +35,11 @@
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
                         "installed_by": ["modules"]
                     },
+                    "bedtools/maskfasta": {
+                        "branch": "master",
+                        "git_sha": "516189e968feb4ebdd9921806988b4c12b4ac2dc",
+                        "installed_by": ["modules"]
+                    },
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",

--- a/modules/nf-core/bedtools/maskfasta/environment.yml
+++ b/modules/nf-core/bedtools/maskfasta/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bedtools=2.30.0

--- a/modules/nf-core/bedtools/maskfasta/main.nf
+++ b/modules/nf-core/bedtools/maskfasta/main.nf
@@ -1,0 +1,36 @@
+process BEDTOOLS_MASKFASTA {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda 'modules/nf-core/bedtools/maskfasta/environment.yml'
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0' :
+        'biocontainers/bedtools:2.30.0--hc088bd4_0' }"
+
+    input:
+    tuple val(meta), path(bed)
+    path  fasta
+
+    output:
+    tuple val(meta), path("*.fa"), emit: fasta
+    path "versions.yml"          , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    bedtools \\
+        maskfasta \\
+        $args \\
+        -fi $fasta \\
+        -bed $bed \\
+        -fo ${prefix}.fa
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bedtools/maskfasta/meta.yml
+++ b/modules/nf-core/bedtools/maskfasta/meta.yml
@@ -1,0 +1,46 @@
+name: bedtools_maskfasta
+description: masks sequences in a FASTA file based on intervals defined in a feature file.
+keywords:
+  - bed
+  - fasta
+  - maskfasta
+tools:
+  - bedtools:
+      description: |
+        A set of tools for genomic analysis tasks, specifically enabling genome arithmetic (merge, count, complement) on various file types.
+      documentation: https://bedtools.readthedocs.io/en/latest/content/tools/intersect.html
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bed:
+      type: file
+      description: Bed feature file
+      pattern: "*.{bed}"
+  - fasta:
+      type: file
+      description: Input fasta file
+      pattern: "*.{fa,fasta}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Output masked fasta file
+      pattern: "*.{fa}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/nextflow.config
+++ b/nextflow.config
@@ -181,6 +181,7 @@ params {
     damage_manipulation_rescale_length_3p                            = 0
     run_pmd_filtering                                                = false
     damage_manipulation_pmdtools_threshold                           = 3
+    damage_manipulation_pmdtools_masked_reference                    = null
     damage_manipulation_pmdtools_reference_mask                      = null
     run_trim_bam                                                     = false
     damage_manipulation_bamutils_trim_double_stranded_none_udg_left  = 0

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -767,6 +767,14 @@
                     "description": "Specify PMDScore threshold for PMDtools.",
                     "help_text": "Specifies the PMDScore threshold to use in the pipeline when filtering BAM files for DNA damage. Only reads which surpass this damage score are considered for downstream DNA analysis.\n\n> Modifies PMDtools parameter: `--threshold`"
                 },
+                "damage_manipulation_pmdtools_masked_reference": {
+                    "type": "string",
+                    "fa_icon": "fas fa-mask",
+                    "help_text": "Supplying a FASTA file to this parameter will result in filtering not conducted for the masked positions. /nThis can alleviate reference bias when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.",
+                    "description": "Specify a FASTA file with positions to be used with pmdtools.",
+                    "pattern": "^\\S+\\.fa?(\\sta)$",
+                    "format": "file-path"
+                },
                 "damage_manipulation_pmdtools_reference_mask": {
                     "type": "string",
                     "fa_icon": "fas fa-mask",
@@ -947,8 +955,7 @@
                     "fa_icon": "fab fa-creative-commons-sampling-plus"
                 },
                 "skip_qualimap": {
-                    "type": "boolean",
-                    "default": false
+                    "type": "boolean"
                 },
                 "snpcapture_bed": {
                     "type": "string",
@@ -1119,9 +1126,6 @@
             "$ref": "#/definitions/mapping"
         },
         {
-            "$ref": "#/definitions/adna_damage_analysis"
-        },
-        {
             "$ref": "#/definitions/bam_filtering"
         },
         {
@@ -1131,34 +1135,28 @@
             "$ref": "#/definitions/deduplication"
         },
         {
-            "$ref": "#/definitions/mitochondrial_to_nuclear_ratio"
-        },
-        {
-            "$ref": "#/definitions/mapping_statistics"
-        },
-        {
             "$ref": "#/definitions/damage_manipulation"
         },
         {
             "$ref": "#/definitions/genotyping"
         },
         {
+            "$ref": "#/definitions/mitochondrial_to_nuclear_ratio"
+        },
+        {
+            "$ref": "#/definitions/mapping_statistics"
+        },
+        {
             "$ref": "#/definitions/adna_damage_analysis"
         },
         {
-            "$ref": "#/definitions/contamination_estimation"
+            "$ref": "#/definitions/feature_annotation_statistics"
         },
         {
             "$ref": "#/definitions/host_removal"
         },
         {
-            "$ref": "#/definitions/feature_annotation_statistics"
+            "$ref": "#/definitions/contamination_estimation"
         }
-    ],
-    "properties": {
-        "damage_manipulation_pmdtools_masked_reference": {
-            "type": "string",
-            "default": "None"
-        }
-    }
+    ]
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -770,7 +770,7 @@
                 "damage_manipulation_pmdtools_masked_reference": {
                     "type": "string",
                     "fa_icon": "fas fa-mask",
-                    "help_text": "Supplying a FASTA file will use this file as reference for `samtools calmd` prior to PMD filtering. /nSetting SNPs part of the used capture set as `N` can alleviate reference bias when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.",
+                    "help_text": "Supplying a FASTA file will use this file as reference for `samtools calmd` prior to PMD filtering. /nSetting the SNPs that are part of the used capture set as `N` can alleviate reference bias when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.",
                     "description": "Specify a masked FASTA file with positions to be used with pmdtools.",
                     "pattern": "^\\S+\\.fa?(\\sta)$",
                     "format": "file-path"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -770,8 +770,8 @@
                 "damage_manipulation_pmdtools_masked_reference": {
                     "type": "string",
                     "fa_icon": "fas fa-mask",
-                    "help_text": "Supplying a FASTA file to this parameter will result in filtering not conducted for the masked positions. /nThis can alleviate reference bias when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.",
-                    "description": "Specify a FASTA file with positions to be used with pmdtools.",
+                    "help_text": "Supplying a FASTA file will use this file as reference for `samtools calmd` prior to PMD filtering. /nSetting SNPs part of the used capture set as `N` can alleviate reference bias when running PMD filtering on capture data, where you might not want the allele of a SNP to be counted as damage when it is a transition.",
+                    "description": "Specify a masked FASTA file with positions to be used with pmdtools.",
                     "pattern": "^\\S+\\.fa?(\\sta)$",
                     "format": "file-path"
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -772,7 +772,7 @@
                     "fa_icon": "fas fa-mask",
                     "help_text": "Supplying a bedfile to this parameter activates masking of the reference fasta at the contained sites prior to running PMDtools. Positions that are in the provided bedfile will be replaced by Ns in the reference genome. \nThis can alleviate reference bias when running PMD filtering on capture data, where you might not want the allele of a transition SNP to be counted as damage. Masking of the reference is done using `bedtools maskfasta`.",
                     "description": "Specify a bedfile to be used to mask the reference fasta prior to running pmdtools.",
-                    "pattern": "^\\S+\\.bed$",
+                    "pattern": "^\\S+\\.bed?(\\.gz)$",
                     "format": "file-path"
                 },
                 "run_trim_bam": {
@@ -948,7 +948,7 @@
                 },
                 "skip_qualimap": {
                     "type": "boolean",
-                    "default": "false"
+                    "default": false
                 },
                 "snpcapture_bed": {
                     "type": "string",
@@ -1154,5 +1154,11 @@
         {
             "$ref": "#/definitions/feature_annotation_statistics"
         }
-    ]
+    ],
+    "properties": {
+        "damage_manipulation_pmdtools_masked_reference": {
+            "type": "string",
+            "default": "None"
+        }
+    }
 }

--- a/subworkflows/local/manipulate_damage.nf
+++ b/subworkflows/local/manipulate_damage.nf
@@ -2,6 +2,7 @@
 // Calculate PMD scores, trim, or rescale DNA damage from mapped reads.
 //
 
+include { BEDTOOLS_MASKFASTA                                      } from '../../modules/nf-core/bedtools/maskfasta/main'
 include { MAPDAMAGE2                                              } from '../../modules/nf-core/mapdamage2/main'
 include { PMDTOOLS_FILTER                                         } from '../../modules/nf-core/pmdtools/filter/main'
 include { BAMUTIL_TRIMBAM                                         } from '../../modules/nf-core/bamutil/trimbam/main'
@@ -13,8 +14,10 @@ include { SAMTOOLS_FLAGSTAT as SAMTOOLS_FLAGSTAT_DAMAGE_FILTERED  } from '../../
 // TODO: Add required channels and channel manipulations for reference-dependent bed masking before pmdtools. Requires multi-ref support before implementation.
 workflow MANIPULATE_DAMAGE {
     take:
-    ch_bam_bai  // [ [ meta ], bam , bai ]
-    ch_fasta    // [ [ meta ], fasta ]
+    ch_bam_bai             // [ [ meta ], bam , bai ]
+    ch_fasta               // [ [ meta ], fasta ]
+    ch_pmd_masked_fasta    // [ [ meta ], masked_fasta ]
+    ch_pmd_bed_for_masking // [ [ meta ], bed_file ]
 
     main:
     ch_versions              = Channel.empty()

--- a/subworkflows/local/manipulate_damage.nf
+++ b/subworkflows/local/manipulate_damage.nf
@@ -91,6 +91,7 @@ workflow MANIPULATE_DAMAGE {
 
         BEDTOOLS_MASKFASTA( ch_masking_input.bed, ch_masking_input.fasta )
         ch_masking_output = BEDTOOLS_MASKFASTA.out.fasta
+        ch_versions       = ch_versions.mix( BEDTOOLS_MASKFASTA.out.versions.first() )
 
         ch_already_masked = ch_masking_prep.alreadymasked
                     .map {

--- a/subworkflows/local/manipulate_damage.nf
+++ b/subworkflows/local/manipulate_damage.nf
@@ -73,11 +73,7 @@ workflow MANIPULATE_DAMAGE {
     }
 
     if ( params.run_pmd_filtering ) {
-        // TODO Add module to produce Masked reference from given references and bed file (with meta specifying the reference it matches)?
-        ch_pmd_masking.dump() // [DUMP] [['id':'Mammoth_MT_Krause'], '', /Users/carlhoff/Documents/git/eager/test/work/bc/021185dc5434c10dbc7ae2206f3640/1240K.pos.list_hs37d5.0based.bed]
-        ch_pmd_for_masking = ch_pmd_masking
-
-        ch_masking_prep = ch_pmd_for_masking
+        ch_masking_prep = ch_pmd_masking
                     .combine( ch_fasta, by: 0 ) // [ [meta], masked_fasta, bed, fasta ]
                     .branch {
                         meta, masked_fasta, bed, fasta ->
@@ -108,7 +104,7 @@ workflow MANIPULATE_DAMAGE {
                         [ meta, fasta ]
                     }
 
-        ch_pmd_fastas = ch_masking_output.join( ch_already_masked ).join( ch_no_masking ).dump()
+        ch_pmd_fastas = ch_masking_output.concat( ch_already_masked, ch_no_masking )
                     .map {
                         // Prepend a new meta that contains the meta.id value as the new_meta.reference attribute
                         WorkflowEager.addNewMetaFromAttributes( it, "id" , "reference" , false )

--- a/subworkflows/local/manipulate_damage.nf
+++ b/subworkflows/local/manipulate_damage.nf
@@ -105,7 +105,7 @@ workflow MANIPULATE_DAMAGE {
                         [ meta, fasta ]
                     }
 
-        ch_pmd_fastas = ch_masking_output.concat( ch_already_masked, ch_no_masking )
+        ch_pmd_fastas = ch_masking_output.mix( ch_already_masked, ch_no_masking )
                     .map {
                         // Prepend a new meta that contains the meta.id value as the new_meta.reference attribute
                         WorkflowEager.addNewMetaFromAttributes( it, "id" , "reference" , false )

--- a/subworkflows/local/reference_indexing.nf
+++ b/subworkflows/local/reference_indexing.nf
@@ -2,9 +2,9 @@
 // Prepare reference indexing for downstream
 //
 
-include { REFERENCE_INDEXING_SINGLE } from '../../subworkflows/local/reference_indexing_single.nf'
-include { REFERENCE_INDEXING_MULTI  } from '../../subworkflows/local/reference_indexing_multi.nf'
-include { GUNZIP as GUNZIP_SNPBED   } from '../../modules/nf-core/gunzip/main.nf'
+include { REFERENCE_INDEXING_SINGLE                                                   } from '../../subworkflows/local/reference_indexing_single.nf'
+include { REFERENCE_INDEXING_MULTI                                                    } from '../../subworkflows/local/reference_indexing_multi.nf'
+include { GUNZIP as GUNZIP_PMDBED; GUNZIP as GUNZIP_PMDFASTA; GUNZIP as GUNZIP_SNPBED } from '../../modules/nf-core/gunzip/main.nf'
 
 workflow REFERENCE_INDEXING {
     take:
@@ -26,7 +26,8 @@ workflow REFERENCE_INDEXING {
         ch_reference_for_mapping = REFERENCE_INDEXING_MULTI.out.reference
         ch_mitochondrion_header  = REFERENCE_INDEXING_MULTI.out.mitochondrion_header
         ch_hapmap                = REFERENCE_INDEXING_MULTI.out.hapmap
-        ch_pmd_mask              = REFERENCE_INDEXING_MULTI.out.pmd_mask
+        ch_pmd_masked_fasta      = REFERENCE_INDEXING_MULTI.out.pmd_masked_fasta
+        ch_pmd_bed_for_masking   = REFERENCE_INDEXING_MULTI.out.pmd_bed_for_masking
         ch_snp_capture_bed       = REFERENCE_INDEXING_MULTI.out.snp_capture_bed
         ch_pileupcaller_snp      = REFERENCE_INDEXING_MULTI.out.pileupcaller_snp
         ch_sexdeterrmine_bed     = REFERENCE_INDEXING_MULTI.out.sexdeterrmine_bed
@@ -37,7 +38,8 @@ workflow REFERENCE_INDEXING {
         REFERENCE_INDEXING_SINGLE ( fasta, fasta_fai, fasta_dict, fasta_mapperindexdir )
         ch_mitochondrion_header  = REFERENCE_INDEXING_SINGLE.out.mitochondrion_header
         ch_hapmap                = REFERENCE_INDEXING_SINGLE.out.hapmap
-        ch_pmd_mask              = REFERENCE_INDEXING_SINGLE.out.pmd_mask
+        ch_pmd_masked_fasta      = REFERENCE_INDEXING_SINGLE.out.pmd_masked_fasta
+        ch_pmd_bed_for_masking   = REFERENCE_INDEXING_MULTI.out.pmd_bed_for_masking
         ch_snp_capture_bed       = REFERENCE_INDEXING_SINGLE.out.snp_capture_bed
         ch_pileupcaller_snp      = REFERENCE_INDEXING_SINGLE.out.pileupcaller_snp
         ch_sexdeterrmine_bed     = REFERENCE_INDEXING_SINGLE.out.sexdeterrmine_bed
@@ -46,17 +48,36 @@ workflow REFERENCE_INDEXING {
         ch_versions = ch_versions.mix( REFERENCE_INDEXING_SINGLE.out.versions )
     }
 
-    // Filter out input options that are not provided
+    // Filter out input options that are not provided and unzip if necessary
     ch_mitochondrion_header = ch_mitochondrion_header
                     .filter{ it[1] != "" }
 
     ch_hapmap = ch_hapmap
                     .filter{ it[1] != "" }
 
-    ch_pmd_mask = ch_pmd_mask
-                    .filter{ it[1] != "" && it[2] != "" }
+    ch_pmd_masked_fasta_gunzip = ch_pmd_masked_fasta
+                    .branch {
+                        meta, pmd_masked_fasta ->
+                        forgunzip: pmd_masked_fasta.extension == "gz"
+                        skip: true
+                    }
+    GUNZIP_PMDFASTA( ch_pmd_masked_fasta_gunzip.forgunzip )
+    ch_pmd_masked_fasta = ch_pmd_masked_fasta_gunzip.skip.mix( GUNZIP_FASTA.out.gunzip )
+                    .filter{ it[1] != "" }
+    ch_version = ch_versions.mix( GUNZIP_PMDFASTA.out.versions )
 
-    ch_capture_bed = ch_snp_capture_bed //optional
+    ch_pmd_bed_for_masking_gunzip = ch_pmd_bed_for_masking
+                    .branch {
+                        meta, pmd_bed_for_masking
+                        forgunzip: pmd_bed_for_masking.extension == "gz"
+                        skip: true
+                    }
+    GUNZIP_PMDBED( ch_pmd_bed_for_masking_gunzip.forgunzip )
+    ch_pmd_bed_for_masking = ch_pmd_bed_for_masking_gunzip.skip.mix( GUNZIP_PMDBED.out.gunzip )
+                    .filter{ it[1] != "" }
+    ch_version = ch_versions.mix( GUNZIP_PMDBED.out.versions )
+
+    ch_capture_bed = ch_snp_capture_bed //bed file input is optional, so no filtering
                     .branch {
                         meta, capture_bed ->
                         input: capture_bed != ""
@@ -70,6 +91,7 @@ workflow REFERENCE_INDEXING {
                     }
     GUNZIP_SNPBED( ch_capture_bed_gunzip.forgunzip )
     ch_capture_bed = GUNZIP_SNPBED.out.gunzip.mix( ch_capture_bed_gunzip.skip ).mix( ch_capture_bed.skip )
+    ch_version = ch_versions.mix( GUNZIP_SNPBED.out.versions )
 
     ch_pileupcaller_snp = ch_pileupcaller_snp
                     .filter{ it[1] != "" && it[2] != "" }
@@ -84,7 +106,8 @@ workflow REFERENCE_INDEXING {
     reference            = ch_reference_for_mapping // [ meta, fasta, fai, dict, mapindex, circular_target ]
     mitochondrion_header = ch_mitochondrion_header  // [ meta, mitochondrion_header ]
     hapmap               = ch_hapmap                // [ meta, hapmap ]
-    pmd_mask             = ch_pmd_mask              // [ meta, masked_fasta, capture_bed ]
+    pmd_masked_fasta     = ch_pmd_masked_fasta      // [ meta, pmd_masked_fasta ]
+    pmd_bed_for_masking  = ch_pmd_bed_for_masking   // [ meta, pmd_bed_for_masking ]
     snp_capture_bed      = ch_capture_bed           // [ meta, capture_bed ]
     pileupcaller_snp     = ch_pileupcaller_snp      // [ meta, pileupcaller_bed, pileupcaller_snp ]
     sexdeterrmine_bed    = ch_sexdeterrmine_bed     // [ meta, sexdet_bed ]

--- a/subworkflows/local/reference_indexing.nf
+++ b/subworkflows/local/reference_indexing.nf
@@ -69,7 +69,7 @@ workflow REFERENCE_INDEXING {
                     }
     GUNZIP_PMDFASTA( ch_pmd_masked_fasta_gunzip.forgunzip )
     ch_pmd_masked_fasta = ch_pmd_masked_fasta_gunzip.skip.mix( GUNZIP_PMDFASTA.out.gunzip ).mix( ch_pmd_masked_fasta.skip )
-    ch_version = ch_versions.mix( GUNZIP_PMDFASTA.out.versions )
+    ch_version = ch_versions.mix( GUNZIP_PMDFASTA.out.versions.first() )
 
     ch_pmd_bed_for_masking = ch_pmd_bed_for_masking
                     .branch {
@@ -85,7 +85,7 @@ workflow REFERENCE_INDEXING {
                     }
     GUNZIP_PMDBED( ch_pmd_bed_for_masking_gunzip.forgunzip )
     ch_pmd_bed_for_masking = ch_pmd_bed_for_masking_gunzip.skip.mix( GUNZIP_PMDBED.out.gunzip ).mix( ch_pmd_bed_for_masking.skip )
-    ch_version = ch_versions.mix( GUNZIP_PMDBED.out.versions )
+    ch_version = ch_versions.mix( GUNZIP_PMDBED.out.versions.first() )
 
     ch_pmd_masking = ch_pmd_masked_fasta
                     .combine( by: 0, ch_pmd_bed_for_masking )
@@ -104,7 +104,7 @@ workflow REFERENCE_INDEXING {
                     }
     GUNZIP_SNPBED( ch_capture_bed_gunzip.forgunzip )
     ch_capture_bed = GUNZIP_SNPBED.out.gunzip.mix( ch_capture_bed_gunzip.skip ).mix( ch_capture_bed.skip )
-    ch_version = ch_versions.mix( GUNZIP_SNPBED.out.versions )
+    ch_version = ch_versions.mix( GUNZIP_SNPBED.out.versions.first() )
 
     ch_pileupcaller_snp = ch_pileupcaller_snp
                     .filter{ it[1] != "" && it[2] != "" }

--- a/subworkflows/local/reference_indexing_multi.nf
+++ b/subworkflows/local/reference_indexing_multi.nf
@@ -29,22 +29,23 @@ workflow REFERENCE_INDEXING_MULTI {
     ch_splitreferencesheet_for_branch = ch_splitreferencesheet_for_map
                                             .map {
                                                 row ->
-                                                    def meta            = [:]
-                                                    meta.id             = row["reference_name"]
-                                                    def fasta           = file(row["fasta"], checkIfExists: true) // mandatory parameter!
-                                                    def fai             = row["fai"] != "" ? file(row["fai"], checkIfExists: true) : ""
-                                                    def dict            = row["dict"] != "" ? file(row["dict"], checkIfExists: true) : ""
-                                                    def mapper_index    = row["mapper_index"] != "" ? file(row["mapper_index"], checkIfExists: true) : ""
-                                                    def circular_target = row["circular_target"]
-                                                    def mitochondrion   = row["mitochondrion_header"]
-                                                    def capture_bed     = row["snpcapture_bed"] != "" ? file(row["snpcapture_bed"], checkIfExists: true) : ""
-                                                    def pileupcaller_bed = row["pileupcaller_bedfile"] != "" ? file(row["pileupcaller_bedfile"], checkIfExists: true) : ""
-                                                    def pileupcaller_snp = row["pileupcaller_snpfile"] != "" ? file(row["pileupcaller_snpfile"], checkIfExists: true) : ""
-                                                    def hapmap          = row["hapmap_file"] != "" ? file(row["hapmap_file"], checkIfExists: true) : ""
-                                                    def pmd_mask        = row["pmdtools_masked_fasta"] != "" ? file(row["pmdtools_masked_fasta"], checkIfExists: true) : ""
-                                                    def sexdet_bed      = row["sexdeterrmine_snp_bed"] != "" ? file(row["sexdeterrmine_snp_bed"], checkIfExists: true) : ""
-                                                    def bedtools_feature = row["bedtools_feature_file"] != "" ? file(row["bedtools_feature_file"], checkIfExists: true) : ""
-                                                    [ meta, fasta, fai, dict, mapper_index, circular_target, mitochondrion, capture_bed, pileupcaller_bed, pileupcaller_snp, hapmap, pmd_mask, sexdet_bed, bedtools_feature ]
+                                                    def meta                = [:]
+                                                    meta.id                 = row["reference_name"]
+                                                    def fasta               = file(row["fasta"], checkIfExists: true) // mandatory parameter!
+                                                    def fai                 = row["fai"] != "" ? file(row["fai"], checkIfExists: true) : ""
+                                                    def dict                = row["dict"] != "" ? file(row["dict"], checkIfExists: true) : ""
+                                                    def mapper_index        = row["mapper_index"] != "" ? file(row["mapper_index"], checkIfExists: true) : ""
+                                                    def circular_target     = row["circular_target"]
+                                                    def mitochondrion       = row["mitochondrion_header"]
+                                                    def capture_bed         = row["snpcapture_bed"] != "" ? file(row["snpcapture_bed"], checkIfExists: true) : ""
+                                                    def pileupcaller_bed    = row["pileupcaller_bedfile"] != "" ? file(row["pileupcaller_bedfile"], checkIfExists: true) : ""
+                                                    def pileupcaller_snp    = row["pileupcaller_snpfile"] != "" ? file(row["pileupcaller_snpfile"], checkIfExists: true) : ""
+                                                    def hapmap              = row["hapmap_file"] != "" ? file(row["hapmap_file"], checkIfExists: true) : ""
+                                                    def pmd_masked_fasta    = row["pmdtools_masked_fasta"] != "" ? file(row["pmdtools_masked_fasta"], checkIfExists: true) : ""
+                                                    def pmd_bed_for_masking = row["pmdtools_bed_for_masking"] != "" ? file(row["pmdtools_bed_for_masking"], checkIfExists: true) : ""
+                                                    def sexdet_bed          = row["sexdeterrmine_snp_bed"] != "" ? file(row["sexdeterrmine_snp_bed"], checkIfExists: true) : ""
+                                                    def bedtools_feature    = row["bedtools_feature_file"] != "" ? file(row["bedtools_feature_file"], checkIfExists: true) : ""
+                                                    [ meta, fasta, fai, dict, mapper_index, circular_target, mitochondrion, capture_bed, pileupcaller_bed, pileupcaller_snp, hapmap, pmd_masked_fasta, pmd_bed_for_masking, sexdet_bed, bedtools_feature ]
                                             }
 
 
@@ -61,11 +62,12 @@ workflow REFERENCE_INDEXING_MULTI {
 
 ch_input_from_referencesheet = ch_splitreferencesheet_for_branch
                             .multiMap {
-                                meta, fasta, fai, dict, mapper_index, circular_target, mitochondrion, capture_bed, pileupcaller_bed, pileupcaller_snp, hapmap, pmd_mask, sexdet_bed, bedtools_feature ->
+                                meta, fasta, fai, dict, mapper_index, circular_target, mitochondrion, capture_bed, pileupcaller_bed, pileupcaller_snp, hapmap, pmd_masked_fasta, pmd_bed_for_masking, sexdet_bed, bedtools_feature ->
                                 generated:            [ meta, fasta, fai, dict, mapper_index, circular_target ]
                                 mitochondrion_header: [ meta, mitochondrion ]
                                 angsd_hapmap:         [ meta, hapmap ]
-                                pmd_mask:             [ meta, pmd_mask, capture_bed ]
+                                pmd_masked_fasta:     [ meta, pmd_masked_fasta ]
+                                pmd_bed_for_masking:  [ meta, pmd_bed_for_masking ]
                                 snp_bed:              [ meta, capture_bed ]
                                 pileupcaller_snp:     [ meta, pileupcaller_bed, pileupcaller_snp ]
                                 sexdeterrmine_bed:    [ meta, sexdet_bed ]
@@ -211,7 +213,8 @@ ch_input_from_referencesheet = ch_splitreferencesheet_for_branch
     reference            = ch_indexmapper_for_reference                      // [ meta, fasta, fai, dict, mapindex, circular_target ]
     mitochondrion_header = ch_input_from_referencesheet.mitochondrion_header // [ meta, mitochondrion ]
     hapmap               = ch_input_from_referencesheet.angsd_hapmap         // [ meta, hapmap ]
-    pmd_mask             = ch_input_from_referencesheet.pmd_mask             // [ meta, pmd_mask, capture_bed ]
+    pmd_masked_fasta     = ch_input_from_referencesheet.pmd_masked_fasta     // [ meta, pmd_masked_fasta ]
+    pmd_bed_for_masking  = ch_input_from_referencesheet.pmd_bed_for_masking  // [ meta, pmd_bed_for_masking ]
     snp_capture_bed      = ch_input_from_referencesheet.snp_bed              // [ meta, capture_bed ]
     pileupcaller_snp     = ch_input_from_referencesheet.pileupcaller_snp     // [ meta, pileupcaller_snp, pileupcaller_bed ]
     sexdeterrmine_bed    = ch_input_from_referencesheet.sexdeterrmine_bed    // [ meta, sexdet_bed ]

--- a/subworkflows/local/reference_indexing_single.nf
+++ b/subworkflows/local/reference_indexing_single.nf
@@ -81,37 +81,40 @@ workflow REFERENCE_INDEXING_SINGLE {
                                     meta, fasta, fai, dict, mapper_index ->
                                     //TODO: add params for snpcapturebed, snpeigenstrat and sexdetbed once implemented
                                     def contamination_estimation_angsd_hapmap = params.contamination_estimation_angsd_hapmap != null ? file( params.contamination_estimation_angsd_hapmap, checkIfExists: true ) : ""
-                                    def pmd_mask                              = params.damage_manipulation_pmdtools_reference_mask != null ? file(params.damage_manipulation_pmdtools_reference_mask, checkIfExists: true ) : ""
+                                    def pmd_masked_fasta                      = params.damage_manipulation_pmdtools_masked_reference != null ? file(params.damage_manipulation_pmdtools_masked_reference, checkIfExists: true ) : ""
+                                    def pmd_bed_for_masking                   = params.damage_manipulation_pmdtools_reference_mask != null ? file(params.damage_manipulation_pmdtools_reference_mask, checkIfExists: true ) : ""
                                     def capture_bed                           = params.snpcapture_bed != null ? file(params.snpcapture_bed, checkIfExists: true ) : ""
                                     def pileupcaller_bed                      = ""
                                     def pileupcaller_snp                      = ""
                                     def sexdet_bed                            = ""
                                     def bedtools_feature                      = params.mapstats_bedtools_featurefile != null ? file(params.mapstats_bedtools_featurefile, checkIfExists: true ) : ""
-                                    [ meta, fasta, fai, dict, mapper_index, params.fasta_circular_target, params.mitochondrion_header, contamination_estimation_angsd_hapmap, pmd_mask, capture_bed, pileupcaller_bed, pileupcaller_snp, sexdet_bed, bedtools_feature ]
+                                    [ meta, fasta, fai, dict, mapper_index, params.fasta_circular_target, params.mitochondrion_header, contamination_estimation_angsd_hapmap, pmd_masked_fasta, pmd_bed_for_masking, capture_bed, pileupcaller_bed, pileupcaller_snp, sexdet_bed, bedtools_feature ]
                                 }
 
     ch_ref_index_single = ch_reference_for_mapping
                                 .multiMap{
-                                    meta, fasta, fai, dict, mapper_index, circular_target, mitochondrion_header, contamination_estimation_angsd_hapmap, pmd_mask, capture_bed, pileupcaller_bed, pileupcaller_snp, sexdet_bed, bedtools_feature ->
-                                    reference:         [ meta, fasta, fai, dict, mapper_index, circular_target ]
-                                    mito_header:       [ meta, mitochondrion_header ]
-                                    hapmap:            [ meta, contamination_estimation_angsd_hapmap ]
-                                    pmd_mask:          [ meta, pmd_mask, capture_bed ]
-                                    snp_bed:           [ meta, capture_bed ]
-                                    pileupcaller_snp:  [ meta, pileupcaller_bed, pileupcaller_snp ]
-                                    sexdeterrmine_bed: [ meta, sexdet_bed ]
-                                    bedtools_feature:  [ meta, bedtools_feature ]
+                                    meta, fasta, fai, dict, mapper_index, circular_target, mitochondrion_header, contamination_estimation_angsd_hapmap, pmd_masked_fasta, pmd_bed_for_masking, capture_bed, pileupcaller_bed, pileupcaller_snp, sexdet_bed, bedtools_feature ->
+                                    reference:           [ meta, fasta, fai, dict, mapper_index, circular_target ]
+                                    mito_header:         [ meta, mitochondrion_header ]
+                                    hapmap:              [ meta, contamination_estimation_angsd_hapmap ]
+                                    pmd_masked_fasta:    [ meta, pmd_masked_fasta ]
+                                    pmd_bed_for_masking: [ meta, pmd_bed_for_masking ]
+                                    snp_bed:             [ meta, capture_bed ]
+                                    pileupcaller_snp:    [ meta, pileupcaller_bed, pileupcaller_snp ]
+                                    sexdeterrmine_bed:   [ meta, sexdet_bed ]
+                                    bedtools_feature:    [ meta, bedtools_feature ]
                                 }
 
     emit:
-    reference            = ch_ref_index_single.reference          // [ meta, fasta, fai, dict, mapindex, circular_target ]
-    mitochondrion_header = ch_ref_index_single.mito_header        // [ meta, mito_header ]
-    hapmap               = ch_ref_index_single.hapmap             // [ meta, hapmap ]
-    pmd_mask             = ch_ref_index_single.pmd_mask           // [ meta, pmd_mask, capture_bed ]
-    snp_capture_bed      = ch_ref_index_single.snp_bed            // [ meta, capture_bed ]
-    pileupcaller_snp     = ch_ref_index_single.pileupcaller_snp   // [ meta, pileupcaller_bed, pileupcaller_snp ]
-    sexdeterrmine_bed    = ch_ref_index_single.sexdeterrmine_bed  // [ meta, sexdet_bed ]
-    bedtools_feature     = ch_ref_index_single.bedtools_feature   // [ meta, bedtools_feature ]
+    reference            = ch_ref_index_single.reference           // [ meta, fasta, fai, dict, mapindex, circular_target ]
+    mitochondrion_header = ch_ref_index_single.mito_header         // [ meta, mito_header ]
+    hapmap               = ch_ref_index_single.hapmap              // [ meta, hapmap ]
+    pmd_masked_fasta     = ch_ref_index_single.pmd_masked_fasta    // [ meta, pmd_masked_fasta ]
+    pmd_bed_for_masking  = ch_ref_index_single.pmd_bed_for_masking // [ meta, pmd_bed_for_masking ]
+    snp_capture_bed      = ch_ref_index_single.snp_bed             // [ meta, capture_bed ]
+    pileupcaller_snp     = ch_ref_index_single.pileupcaller_snp    // [ meta, pileupcaller_bed, pileupcaller_snp ]
+    sexdeterrmine_bed    = ch_ref_index_single.sexdeterrmine_bed   // [ meta, sexdet_bed ]
+    bedtools_feature     = ch_ref_index_single.bedtools_feature    // [ meta, bedtools_feature ]
     versions             = ch_versions
 
 }

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -527,7 +527,7 @@ workflow EAGER {
     // SUBWORKFLOW: aDNA Damage Manipulation
 
     if ( params.run_mapdamage_rescaling || params.run_pmd_filtering || params.run_trim_bam ) {
-        MANIPULATE_DAMAGE( ch_dedupped_bams, ch_fasta_for_deduplication.fasta, REFERENCE_INDEXING.out.pmd_masked_fasta, REFERENCE_INDEXING.pmd_bed_for_masking )
+        MANIPULATE_DAMAGE( ch_dedupped_bams, ch_fasta_for_deduplication.fasta, REFERENCE_INDEXING.out.pmd_masking )
         ch_multiqc_files       = ch_multiqc_files.mix( MANIPULATE_DAMAGE.out.flagstat.collect{it[1]}.ifEmpty([]) )
         ch_versions            = ch_versions.mix( MANIPULATE_DAMAGE.out.versions )
         ch_bams_for_genotyping = params.genotyping_source == 'rescaled' ? MANIPULATE_DAMAGE.out.rescaled : params.genotyping_source == 'pmd' ? MANIPULATE_DAMAGE.out.filtered : params.genotyping_source == 'trimmed' ? MANIPULATE_DAMAGE.out.trimmed : ch_dedupped_bams

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -525,10 +525,9 @@ workflow EAGER {
 
     //
     // SUBWORKFLOW: aDNA Damage Manipulation
-    // TODO: Add pmd_mask and snp_capture input
 
     if ( params.run_mapdamage_rescaling || params.run_pmd_filtering || params.run_trim_bam ) {
-        MANIPULATE_DAMAGE( ch_dedupped_bams, ch_fasta_for_deduplication.fasta )
+        MANIPULATE_DAMAGE( ch_dedupped_bams, ch_fasta_for_deduplication.fasta, REFERENCE_INDEXING.out.pmd_masked_fasta, REFERENCE_INDEXING.pmd_bed_for_masking )
         ch_multiqc_files       = ch_multiqc_files.mix( MANIPULATE_DAMAGE.out.flagstat.collect{it[1]}.ifEmpty([]) )
         ch_versions            = ch_versions.mix( MANIPULATE_DAMAGE.out.versions )
         ch_bams_for_genotyping = params.genotyping_source == 'rescaled' ? MANIPULATE_DAMAGE.out.rescaled : params.genotyping_source == 'pmd' ? MANIPULATE_DAMAGE.out.filtered : params.genotyping_source == 'trimmed' ? MANIPULATE_DAMAGE.out.trimmed : ch_dedupped_bams


### PR DESCRIPTION
This adds the options to run PMDtools only on a specific part of the genome within the damage manipulation subworkflow. Input options are the mapping reference, an already masked fasta file and a bed file for masking of the mapping reference.
This closes #1029.
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
