### PR TITLE
add ext.prefix

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -40,6 +40,7 @@ process {
     withName: FASTQC {
         tag = { "${meta.sample_id}_${meta.library_id}_L${meta.lane}" }
         ext.args = '--quiet'
+        ext.prefix = { "${meta.sample_id}_${meta.library_id}_L${meta.lane}" }
         publishDir = [
             path: { "${params.outdir}/preprocessing/fastqc_raw/" },
             mode: params.publish_dir_mode,
@@ -49,6 +50,7 @@ process {
     withName: FASTQC_PROCESSED {
         tag = { "${meta.sample_id}_${meta.library_id}_L${meta.lane}" }
         ext.args = '--quiet'
+        ext.prefix = { "${meta.sample_id}_${meta.library_id}_L${meta.lane}" }
         publishDir = [
             path: { "${params.outdir}/preprocessing/fastqc_processed/" },
             mode: params.publish_dir_mode,


### PR DESCRIPTION
Adds missing `ext.prefix` to FASTQC modules.
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
