### PR TITLE
Bump BWA version

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -67,27 +67,27 @@
                     },
                     "bwa/aln": {
                         "branch": "master",
-                        "git_sha": "6278bf9afd4a4b2d00fa6052250e73da3d91546f",
+                        "git_sha": "e0ff65e1fb313677de09f5f477ae3da30ce19b7b",
                         "installed_by": ["fastq_align_bwaaln"]
                     },
                     "bwa/index": {
                         "branch": "master",
-                        "git_sha": "6278bf9afd4a4b2d00fa6052250e73da3d91546f",
+                        "git_sha": "e0ff65e1fb313677de09f5f477ae3da30ce19b7b",
                         "installed_by": ["modules"]
                     },
                     "bwa/mem": {
                         "branch": "master",
-                        "git_sha": "1e2b7fb7106852388610c0360d234b0829eb980e",
+                        "git_sha": "e0ff65e1fb313677de09f5f477ae3da30ce19b7b",
                         "installed_by": ["modules"]
                     },
                     "bwa/sampe": {
                         "branch": "master",
-                        "git_sha": "1e2b7fb7106852388610c0360d234b0829eb980e",
+                        "git_sha": "e0ff65e1fb313677de09f5f477ae3da30ce19b7b",
                         "installed_by": ["fastq_align_bwaaln"]
                     },
                     "bwa/samse": {
                         "branch": "master",
-                        "git_sha": "1e2b7fb7106852388610c0360d234b0829eb980e",
+                        "git_sha": "e0ff65e1fb313677de09f5f477ae3da30ce19b7b",
                         "installed_by": ["fastq_align_bwaaln"]
                     },
                     "cat/fastq": {

--- a/modules/nf-core/bwa/aln/environment.yml
+++ b/modules/nf-core/bwa/aln/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::bwa=0.7.17
+  - bioconda::bwa=0.7.18

--- a/modules/nf-core/bwa/aln/main.nf
+++ b/modules/nf-core/bwa/aln/main.nf
@@ -4,8 +4,8 @@ process BWA_ALN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bwa:0.7.17--h5bf99c6_8' :
-        'biocontainers/bwa:0.7.17--h5bf99c6_8' }"
+        'https://depot.galaxyproject.org/singularity/bwa:0.7.18--he4a0461_0' :
+        'biocontainers/bwa:0.7.18--he4a0461_0' }"
 
     input:
     tuple val(meta) , path(reads)

--- a/modules/nf-core/bwa/aln/meta.yml
+++ b/modules/nf-core/bwa/aln/meta.yml
@@ -15,7 +15,7 @@ tools:
         BWA is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: http://bio-bwa.sourceforge.net/
-      documentation: http://bio-bwa.sourceforge.net/
+      documentation: https://bio-bwa.sourceforge.net/bwa.shtml
       doi: "10.1093/bioinformatics/btp324"
       licence: ["GPL-3.0-or-later"]
 input:
@@ -56,3 +56,4 @@ authors:
   - "@jfy133"
 maintainers:
   - "@jfy133"
+  - "@gallvp"

--- a/modules/nf-core/bwa/index/environment.yml
+++ b/modules/nf-core/bwa/index/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::bwa=0.7.17
+  - bioconda::bwa=0.7.18

--- a/modules/nf-core/bwa/index/main.nf
+++ b/modules/nf-core/bwa/index/main.nf
@@ -4,8 +4,8 @@ process BWA_INDEX {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bwa:0.7.17--hed695b0_7' :
-        'biocontainers/bwa:0.7.17--hed695b0_7' }"
+        'https://depot.galaxyproject.org/singularity/bwa:0.7.18--he4a0461_0' :
+        'biocontainers/bwa:0.7.18--he4a0461_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/bwa/index/meta.yml
+++ b/modules/nf-core/bwa/index/meta.yml
@@ -11,7 +11,7 @@ tools:
         BWA is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: http://bio-bwa.sourceforge.net/
-      documentation: http://www.htslib.org/doc/samtools.html
+      documentation: https://bio-bwa.sourceforge.net/bwa.shtml
       arxiv: arXiv:1303.3997
       licence: ["GPL-3.0-or-later"]
 input:
@@ -43,3 +43,4 @@ authors:
 maintainers:
   - "@drpatelh"
   - "@maxulysse"
+  - "@gallvp"

--- a/modules/nf-core/bwa/mem/environment.yml
+++ b/modules/nf-core/bwa/mem/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bwa=0.7.17
+  - bwa=0.7.18
   # renovate: datasource=conda depName=bioconda/samtools
-  - samtools=1.18
-  - htslib=1.18
+  - samtools=1.20
+  - htslib=1.20.0

--- a/modules/nf-core/bwa/mem/main.nf
+++ b/modules/nf-core/bwa/mem/main.nf
@@ -4,17 +4,21 @@ process BWA_MEM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:9c0128851101dafef65cef649826d2dbe6bedd7e-0' :
-        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:9c0128851101dafef65cef649826d2dbe6bedd7e-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e-0' :
+        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:1bd8542a8a0b42e0981337910954371d0230828e-0' }"
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(meta) , path(reads)
     tuple val(meta2), path(index)
+    tuple val(meta3), path(fasta)
     val   sort_bam
 
     output:
-    tuple val(meta), path("*.bam"), emit: bam
-    path  "versions.yml"          , emit: versions
+    tuple val(meta), path("*.bam")  , emit: bam,    optional: true
+    tuple val(meta), path("*.cram") , emit: cram,   optional: true
+    tuple val(meta), path("*.csi")  , emit: csi,    optional: true
+    tuple val(meta), path("*.crai") , emit: crai,   optional: true
+    path  "versions.yml"            , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,6 +28,13 @@ process BWA_MEM {
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def samtools_command = sort_bam ? 'sort' : 'view'
+    def extension = args2.contains("--output-fmt sam")   ? "sam" :
+                    args2.contains("--output-fmt cram")  ? "cram":
+                    sort_bam && args2.contains("-O cram")? "cram":
+                    !sort_bam && args2.contains("-C")    ? "cram":
+                    "bam"
+    def reference = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
+    if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
     """
     INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
 
@@ -32,7 +43,7 @@ process BWA_MEM {
         -t $task.cpus \\
         \$INDEX \\
         $reads \\
-        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam -
+        | samtools $samtools_command $args2 ${reference} --threads $task.cpus -o ${prefix}.${extension} -
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -42,9 +53,19 @@ process BWA_MEM {
     """
 
     stub:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def samtools_command = sort_bam ? 'sort' : 'view'
+    def extension = args2.contains("--output-fmt sam")   ? "sam" :
+                    args2.contains("--output-fmt cram")  ? "cram":
+                    sort_bam && args2.contains("-O cram")? "cram":
+                    !sort_bam && args2.contains("-C")    ? "cram":
+                    "bam"
     """
-    touch ${prefix}.bam
+    touch ${prefix}.${extension}
+    touch ${prefix}.csi
+    touch ${prefix}.crai
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bwa/mem/meta.yml
+++ b/modules/nf-core/bwa/mem/meta.yml
@@ -14,7 +14,7 @@ tools:
         BWA is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: http://bio-bwa.sourceforge.net/
-      documentation: http://www.htslib.org/doc/samtools.html
+      documentation: https://bio-bwa.sourceforge.net/bwa.shtml
       arxiv: arXiv:1303.3997
       licence: ["GPL-3.0-or-later"]
 input:
@@ -37,6 +37,10 @@ input:
       type: file
       description: BWA genome index files
       pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
+  - fasta:
+      type: file
+      description: Reference genome in FASTA format
+      pattern: "*.{fasta,fa}"
   - sort_bam:
       type: boolean
       description: use samtools sort (true) or samtools view (false)
@@ -46,6 +50,18 @@ output:
       type: file
       description: Output BAM file containing read alignments
       pattern: "*.{bam}"
+  - cram:
+      type: file
+      description: Output CRAM file containing read alignments
+      pattern: "*.{cram}"
+  - csi:
+      type: file
+      description: Optional index file for BAM file
+      pattern: "*.{csi}"
+  - crai:
+      type: file
+      description: Optional index file for CRAM file
+      pattern: "*.{crai}"
   - versions:
       type: file
       description: File containing software versions
@@ -53,6 +69,8 @@ output:
 authors:
   - "@drpatelh"
   - "@jeremy1805"
+  - "@matthdsm"
 maintainers:
   - "@drpatelh"
   - "@jeremy1805"
+  - "@matthdsm"

--- a/modules/nf-core/bwa/sampe/meta.yml
+++ b/modules/nf-core/bwa/sampe/meta.yml
@@ -16,7 +16,7 @@ tools:
         BWA is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: http://bio-bwa.sourceforge.net/
-      documentation: http://bio-bwa.sourceforge.net/
+      documentation: https://bio-bwa.sourceforge.net/bwa.shtml
       doi: "10.1093/bioinformatics/btp324"
       licence: ["GPL-3.0-or-later"]
 input:

--- a/modules/nf-core/bwa/samse/meta.yml
+++ b/modules/nf-core/bwa/samse/meta.yml
@@ -16,7 +16,7 @@ tools:
         BWA is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: http://bio-bwa.sourceforge.net/
-      documentation: http://bio-bwa.sourceforge.net/
+      documentation: https://bio-bwa.sourceforge.net/bwa.shtml
       doi: "10.1093/bioinformatics/btp324"
       licence: ["GPL-3.0-or-later"]
 input:

--- a/workflows/eager.nf
+++ b/workflows/eager.nf
@@ -182,7 +182,7 @@ workflow EAGER {
     ch_reference_for_mapping = REFERENCE_INDEXING.out.reference
             .map{
                 meta, fasta, fai, dict, index, circular_target ->
-                [ meta, index ]
+                [ meta, index, fasta ]
             }
 
     MAP ( ch_reads_for_mapping, ch_reference_for_mapping )


### PR DESCRIPTION
Update BWA. This has the convenient side effect that the new BWA Docker images come in the right format and work with recent Docker versions. This should work around Docker's infamous deprecation errors in CI tests for eager.

<!--
# nf-core/eager pull request

Many thanks for contributing to nf-core/eager!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
