### PR TITLE
DSL2: Sharding Tweaks

### DIFF
--- a/subworkflows/local/map.nf
+++ b/subworkflows/local/map.nf
@@ -133,6 +133,11 @@ workflow MAP {
 
     // Only run merge lanes if we have more than one BAM to merge!
     ch_input_for_lane_merge = ch_mapped_lane_bam
+                                .toSortedList {
+                                    a, b ->
+                                    a[0]['lane'] <=> b[0]['lane'] ?: a[0]['colour_chemistry'] <=> b[0]['colour_chemistry'] ?: a[0]['shard_number'] <=> b[0]['shard_number']
+                                }
+                                .flatMap()
                                 .map {
                                     meta, bam ->
                                     new_meta = meta.clone().findAll{ it.key !in ['lane', 'colour_chemistry', 'shard_number'] }


### PR DESCRIPTION
BAM file names are sorted before merging in order to stabilise downstream headers by always including the first `shard_number` (also `lane` and `colour_chemistry`) in the header.
Supposed to close #1104

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
