### PR TITLE
removal of bugged nf-core utils function call 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#1114](https://github.com/nf-core/eager/issues/1114) Removed bugged call to nf-core utils template function, behaving inconsistently across https and local input paths. not necessary for our samplesheet validation
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#1114](https://github.com/nf-core/eager/issues/1114) Removed bugged call to nf-core utils template function, behaving inconsistently across https and local input paths. not necessary for our samplesheet validation
-
 ### `Dependencies`
 
 ### `Deprecated`

--- a/subworkflows/local/utils_nfcore_eager_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_eager_pipeline/main.nf
@@ -118,10 +118,6 @@ workflow PIPELINE_INITIALISATION {
                 }
             [ meta, r1, r2, bam ]
         }
-        .groupTuple()
-        .map { samplesheet ->
-            validateInputSamplesheet(samplesheet)
-        }
 
     // - Only single-ended specified for BAM files
     ch_samplesheet_for_branch.bam


### PR DESCRIPTION
Call of template nf-core utils template checking of samplesheet is not necessary and currently bugged (behaves incorrectly with https file paths as inputs, raises errors for all other inputs, as expected, but not necessary to raise error).

Solution for nf-core/eager: remove call

Todo: broader fix for deeper nextflow issue, fix nf-core template

Related to #1114 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/eager/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/eager _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
