### PR TITLE
Remove duplicate metagenomics withName blocks in modules.config (closes #1173)

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -939,78 +939,6 @@ process {
         ]
     }
 
-    withName: BBMAP_BBDUK {
-        tag        = { "${meta.reference}|${meta.sample_id}_${meta.library_id}" }
-        ext.args   = { "entropymask=f entropy=${params.metagenomics_complexity_entropy}" }
-        ext.prefix = { "${meta.sample_id}_${meta.library_id}_${meta.reference}_complexity" }
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/complexity_filter/bbduk/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{fastq.gz,log}',
-            enabled: params.metagenomics_complexity_savefastq,
-        ]
-    }
-
-    withName: MALT_RUN {
-        ext.args   = [
-            "-m ${params.metagenomics_malt_mode}",
-            "-at ${params.metagenomics_malt_alignmentmode}",
-            "-top ${params.metagenomics_malt_toppercent}",
-            "-id ${params.metagenomics_malt_minpercentidentity}",
-            "-mq ${params.metagenomics_malt_maxqueries}",
-            "--memoryMode ${params.metagenomics_malt_memorymode}",
-            params.metagenomics_malt_minsupportmode == "percent" ? "-supp ${params.metagenomics_malt_minsupportpercent}" : "-sup ${params.metagenomics_malt_minsupportreads}",
-            params.metagenomics_malt_savereads ? "--alignments ./" : "",
-        ].join(' ').trim()
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/profiling/malt/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{rma6,log,sam.gz}',
-        ]
-        ext.prefix = { "${meta.label}_${meta.id}-run" }
-    }
-
-    withName: CAT_CAT_MALT {
-        ext.prefix = { "${meta.id}_runtime_log_concatenated.log" }
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/profiling/malt/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{log}',
-        ]
-    }
-
-    withName: KRAKEN2_KRAKEN2 {
-        tag        = { "${meta.sample_id}|single_end_mode_${meta.single_end}" }
-        ext.args   = [
-            params.metagenomics_kraken2_saveminimizers ? "--report-minimizer-data" : ""
-        ].join(' ').trim()
-        ext.prefix = { "${meta.sample_id}_${meta.library_id}_${meta.reference}" }
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/profiling/kraken2/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{txt,fastq.gz}',
-        ]
-    }
-
-    withName: KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
-        tag        = { "single_end_mode_${meta.single_end}" }
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/profiling/krakenuniq/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{txt,fastq.gz}',
-        ]
-        ext.prefix = { "${meta.single_end}" }
-    }
-
-    withName: METAPHLAN_METAPHLAN {
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/profiling/metaphlan/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{biom,txt}',
-        ]
-        ext.prefix = { "${meta.sample_id}_${meta.library_id}_${meta.reference}" }
-    }
-
     withName: MALTEXTRACT {
         ext.args   = {
             [
@@ -1032,44 +960,6 @@ process {
             pattern: 'results',
             saveAs: { "${meta.id}" },
         ]
-    }
-
-    withName: MEGAN_RMA2INFO {
-        tag        = { "${meta.id}" }
-        ext.args   = "-c2c Taxonomy"
-        ext.prefix = { "${meta.id}" }
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/postprocessing/megan_summaries/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{txt.gz,megan}',
-        ]
-    }
-
-    withName: AMPS {
-        publishDir    = [
-            path: { "${params.outdir}/metagenomics/postprocessing/maltextract/" },
-            mode: params.publish_dir_mode,
-            pattern: 'results',
-        ]
-        errorStrategy = 'ignore'
-    }
-
-    withName: TAXPASTA_MERGE {
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/postprocessing/taxpasta/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{csv,tsv,ods,xlsx,arrow,parquet,biom}',
-        ]
-        ext.args   = { "--profiler ${meta.profiler} --output ${meta.profiler}_taxpasta_table.tsv" }
-    }
-
-    withName: TAXPASTA_STANDARDISE {
-        publishDir = [
-            path: { "${params.outdir}/metagenomics/postprocessing/taxpasta/" },
-            mode: params.publish_dir_mode,
-            pattern: '*.{csv,tsv,ods,xlsx,arrow,parquet,biom}',
-        ]
-        ext.args   = { "--profiler ${meta.profiler} --output ${meta.profiler}taxpasta_table.tsv" }
     }
 
     //
@@ -1348,6 +1238,7 @@ process {
     }
 
     withName: KRAKEN2_KRAKEN2 {
+        tag        = { "${meta.sample_id}|single_end_mode_${meta.single_end}" }
         ext.args   = [
             params.metagenomics_kraken2_saveminimizers ? "--report-minimizer-data" : ""
         ].join(' ').trim()
@@ -1367,6 +1258,8 @@ process {
     }
 
     withName: KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
+        tag        = { "single_end_mode_${meta.single_end}" }
+        ext.prefix = { "${meta.single_end}" }
         publishDir = [
             [
                 path: { "${params.outdir}/metagenomics/krakenuniq/data/" },
@@ -1481,14 +1374,6 @@ process {
                 mode: params.publish_dir_mode,
                 pattern: '*.flagstat',
             ]
-        ]
-    }
-
-    withName: '.*MERGE_LIBRARIES:SAMTOOLS_MERGE_LIBRARIES' {
-        tag        = { "${meta.reference}|${meta.sample_id}" }
-        ext.prefix = { "${meta.sample_id}_${meta.reference}_unsorted" }
-        publishDir = [
-            enabled: false
         ]
     }
 


### PR DESCRIPTION
Closes #1173. Approach as agreed with @TCLamnidis in the issue.

## Changes

An older set of metagenomics `withName` blocks lived in the `AUTHENTICATION`
section of `conf/modules.config`, using the outdated
`metagenomics/profiling/…` + `metagenomics/postprocessing/…` publishDir
layout. They duplicated the blocks in the `// METAGENOMIC SCREENING`
section, which use the canonical `<section>/<tool>/{data,stats}/` layout.
Nextflow's last-definition-wins meant the screening-section blocks were
already the effective config, so the old ones were dead weight.

- Removed the 10 outdated duplicates: `BBMAP_BBDUK`, `MALT_RUN`,
  `CAT_CAT_MALT`, `KRAKEN2_KRAKEN2`, `KRAKENUNIQ_PRELOADEDKRAKENUNIQ`,
  `METAPHLAN_METAPHLAN`, `MEGAN_RMA2INFO`, `AMPS`, `TAXPASTA_MERGE`,
  `TAXPASTA_STANDARDISE`.
- Moved the directives that only existed on the old blocks onto the
  screening-section blocks, ordered per `docs/development/code_conventions.md`
  (`tag` → `ext.args` → `ext.prefix` → `publishDir`):
  - `KRAKEN2_KRAKEN2`: `tag`
  - `KRAKENUNIQ_PRELOADEDKRAKENUNIQ`: `tag` + `ext.prefix`
- Removed a byte-identical duplicate of
  `.*MERGE_LIBRARIES:SAMTOOLS_MERGE_LIBRARIES` in the `LIBRARY MERGE` section.

`MALTEXTRACT` is left untouched — it has no screening-section counterpart
(not a duplicate), so relocating/retargeting it is out of scope here. Happy
to do that as a follow-up if wanted.

## Points for review

- The moved `KRAKEN2_KRAKEN2` `tag` (`{ "${meta.sample_id}|single_end_mode_${meta.single_end}" }`)
  does not include `${meta.reference}`, which `code_conventions.md` asks for
  on reference-specific processes. I moved it verbatim per "retain and move"
  rather than redesign it (the `single_end_mode` grouping looks intentional
  for metagenomic screening). Happy to align it to the
  `${meta.reference}|${meta.sample_id}_*` format if you'd prefer.
- No `CHANGELOG.md` entry — `dev` doesn't appear to track per-PR changelog
  entries during the DSL2 work (last touched 2023). Glad to add one.
- `docs/output.md` unchanged: effective publishDir paths are the same (the
  screening-section blocks that already won are untouched).
- Didn't run `nf-core pipelines lint` locally; verified structurally
  (no remaining duplicate `withName` selectors, braces balanced, directive
  order per code conventions).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests! — config-only cleanup, covered by existing pipeline tests
- [ ] Make sure your code lints (`nf-core pipelines lint`). — not run locally, see above
- [ ] Ensure the test suite passes — via CI
- [ ] `CHANGELOG.md` is updated. — see above